### PR TITLE
Add tarot interpretation endpoint with AI and rate limiting

### DIFF
--- a/API/Controllers/Tarot/TarotController.cs
+++ b/API/Controllers/Tarot/TarotController.cs
@@ -1,6 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using SarasBloggAPI.Services.Tarot;
+using SarasBloggAPI.DTOs.Tarot;
+
 namespace SarasBloggAPI.Controllers.Tarot;
 
-public class TarotController
+[ApiController]
+[Route("api/[controller]")]
+[EnableRateLimiting("tarot")]
+public class TarotController : ControllerBase
 {
-    
+    private readonly TarotService _tarotService;
+
+    public TarotController(TarotService tarotService)
+    {
+        _tarotService = tarotService;
+    }
+
+    [HttpPost("interpret")]
+    public async Task<ActionResult<TarotInterpretResponse>> Interpret([FromBody] TarotInterpretRequest request)
+    {
+        var result = await _tarotService.InterpretAsync(request);
+
+        return Ok(new TarotInterpretResponse
+        {
+            Interpretation = result
+        });
+    }
 }

--- a/API/Controllers/Tarot/TarotController.cs
+++ b/API/Controllers/Tarot/TarotController.cs
@@ -22,6 +22,15 @@ public class TarotController : ControllerBase
     {
         var result = await _tarotService.InterpretAsync(request);
 
+        if (string.IsNullOrWhiteSpace(result))
+        {
+            return StatusCode(500, new
+            {
+                error = "interpretation_failed",
+                message = "Could not generate interpretation."
+            });
+        }
+
         return Ok(new TarotInterpretResponse
         {
             Interpretation = result

--- a/API/DTOs/Tarot/TarotInterpretRequest.cs
+++ b/API/DTOs/Tarot/TarotInterpretRequest.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 namespace SarasBloggAPI.DTOs.Tarot;
 
 public class TarotInterpretRequest
 {
-    
+    public string Question { get; set; } = string.Empty;
+    public List<string> Cards { get; set; } = new();
+    public string Language { get; set; } = "en";
 }

--- a/API/DTOs/Tarot/TarotInterpretRequest.cs
+++ b/API/DTOs/Tarot/TarotInterpretRequest.cs
@@ -1,9 +1,12 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 namespace SarasBloggAPI.DTOs.Tarot;
 
 public class TarotInterpretRequest
 {
     public string Question { get; set; } = string.Empty;
+    [MinLength(1, ErrorMessage = "At least 1 card is required.")]
+    [MaxLength(3, ErrorMessage = "Maximum 3 cards allowed.")]
     public List<string> Cards { get; set; } = new();
     public string Language { get; set; } = "en";
 }

--- a/API/DTOs/Tarot/TarotInterpretResponse.cs
+++ b/API/DTOs/Tarot/TarotInterpretResponse.cs
@@ -2,5 +2,5 @@ namespace SarasBloggAPI.DTOs.Tarot;
 
 public class TarotInterpretResponse
 {
-    
+    public string Interpretation { get; set; } = string.Empty;
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -16,6 +16,8 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using System.Security.Claims;
 using AngleSharp.Dom;
 using Ganss.Xss;
+using Microsoft.AspNetCore.RateLimiting;
+using SarasBloggAPI.Services.Tarot;
 
 
 namespace SarasBloggAPI
@@ -207,6 +209,29 @@ namespace SarasBloggAPI
             // Används för kortlivade auth-flöden (t.ex. external login codes → tokens)
             // Ersätter osäkra/långa querystrings och försvinner automatiskt vid restart
             builder.Services.AddMemoryCache();
+            
+            builder.Services.AddRateLimiter(options =>
+            {
+                options.OnRejected = async (context, token) =>
+                {
+                    context.HttpContext.Response.StatusCode = 429;
+                    context.HttpContext.Response.ContentType = "application/json";
+
+                    await context.HttpContext.Response.WriteAsync("""
+{
+  "error": "too_many_requests",
+  "message": "Please wait before trying again."
+}
+""", token);
+                };
+
+                options.AddFixedWindowLimiter("tarot", config =>
+                {
+                    config.PermitLimit = 10;
+                    config.Window = TimeSpan.FromMinutes(1);
+                    config.QueueLimit = 0;
+                });
+            });
 
             // FILE HELPER: Local för Development, GitHub för Test/Prod
             if (builder.Environment.IsDevelopment())
@@ -224,6 +249,9 @@ namespace SarasBloggAPI
             builder.Services.AddScoped<ForbiddenWordManager>();
             builder.Services.AddScoped<AboutMeManager>();
             builder.Services.AddScoped<IAboutMeImageService, AboutMeImageService>();
+            
+            builder.Services.AddScoped<TarotService>();
+            
             builder.Services.AddScoped<ContactMeManager>();
             builder.Services.AddScoped<UserManagerService>();
             builder.Services.AddScoped<NewPostNotifier>();
@@ -406,6 +434,8 @@ namespace SarasBloggAPI
             }
 
             app.UseCors("SarasPolicy");
+            
+            app.UseRateLimiter();
 
             app.UseAuthentication();
 

--- a/API/Services/Tarot/TarotService.cs
+++ b/API/Services/Tarot/TarotService.cs
@@ -1,6 +1,95 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using SarasBloggAPI.DTOs.Tarot;
+
 namespace SarasBloggAPI.Services.Tarot;
 
 public class TarotService
 {
+    private readonly IConfiguration _configuration;
+    private readonly HttpClient _httpClient = new HttpClient();
+
+    public TarotService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public async Task<string> InterpretAsync(TarotInterpretRequest request)
+    {
+        var prompt = BuildPrompt(request);
+
+        // TEMP: return prompt for testing before hooking up OpenAI
+        return await CallOpenAI(prompt);
+    }
+
+    private string BuildPrompt(TarotInterpretRequest request)
+    {
+        var cardsText = string.Join(", ", request.Cards);
+        var languageInstruction = request.Language == "sv"
+            ? "Respond in Swedish."
+            : "Respond in English.";
+
+        return $@"
+            {languageInstruction}
+            User question: {request.Question}
+
+            Cards drawn: {cardsText}
+
+            Provide a reflective tarot interpretation.
+            - Do not predict the future
+            - Do not give absolute answers
+            - Speak directly to the user
+            - Use a calm, reflective and slightly poetic tone
+            - Keep the response concise (max 150 words)
+            - Write in plain text
+            - Do not use markdown, bullet points, or symbols
+            - Use short paragraphs
+            - First give the interpretation, then end with one reflective question
+            - When multiple cards are drawn, reflect on how they relate to each other
+            - Treat the cards as parts of a single story rather than separate meanings
+            - Avoid generic opening phrases like ""It feels like"" or ""This suggests""
+            - Avoid repeating similar sentence structures
+            - Focus on personal reflection rather than explaining the cards
+            ";
+    }
     
+    private async Task<string> CallOpenAI(string prompt)
+    {
+        var apiKey = _configuration["OpenAI:ApiKey"];
+
+        if (string.IsNullOrEmpty(apiKey))
+            throw new Exception("OPENAI_API_KEY is missing");
+
+        var requestBody = new
+        {
+            model = "gpt-4o-mini",
+            messages = new[]
+            {
+                new { role = "user", content = prompt }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(requestBody);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://api.openai.com/v1/chat/completions");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.SendAsync(request);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"OpenAI error: {responseContent}");
+
+        using var doc = JsonDocument.Parse(responseContent);
+        var content = doc.RootElement
+            .GetProperty("choices")[0]
+            .GetProperty("message")
+            .GetProperty("content")
+            .GetString();
+
+        return content ?? "No response from AI.";
+    }
 }


### PR DESCRIPTION
This PR introduces a new tarot interpretation endpoint powered by OpenAI.

The endpoint allows a user to send a question together with 1–3 tarot cards and receive a reflective interpretation. The response is intentionally designed to be non-predictive and focused on personal reflection.

### What’s included

- New TarotController with POST /api/tarot/interpret
- TarotService handling prompt creation and OpenAI integration
- DTOs for request and response
- Prompt tuned for:
  - reflective tone
  - no future predictions
  - concise output
  - ending with a single question
- Basic rate limiting (10 requests per minute per IP)
- Proper 429 response with JSON when limit is exceeded

### Notes

- Rate limiting is intentionally simple for now
- Prompt is minimal by design – relies on model quality rather than over-engineering
- Ready to be consumed by frontend (Svelte)

### Next steps (not in this PR)

- Frontend integration
- UI handling for rate limiting (429)
- Optional caching of responses
- Possible refinement of prompt per card count