### PR TITLE
Feature/tarot modes api

### DIFF
--- a/API/Controllers/Tarot/TarotController.cs
+++ b/API/Controllers/Tarot/TarotController.cs
@@ -31,7 +31,7 @@ public class TarotController : ControllerBase
                 });
             }
 
-            Console.WriteLine($"[Tarot] Interpret called - Cards: {request.Cards.Count}, Lang: {request.Language}");
+            Console.WriteLine($"[Tarot] Interpret called - Cards: {request.Cards.Count}, Lang: {request.Language}, Mode: {request.Mode ?? "soft"}");
 
             var result = await _tarotService.InterpretAsync(request);
 

--- a/API/DTOs/Tarot/TarotInterpretRequest.cs
+++ b/API/DTOs/Tarot/TarotInterpretRequest.cs
@@ -9,4 +9,5 @@ public class TarotInterpretRequest
     [MaxLength(3, ErrorMessage = "Maximum 3 cards allowed.")]
     public List<string> Cards { get; set; } = new();
     public string Language { get; set; } = "en";
+    public string? Mode { get; set; } = "soft";
 }

--- a/API/Services/Tarot/TarotService.cs
+++ b/API/Services/Tarot/TarotService.cs
@@ -30,6 +30,51 @@ public class TarotService
         var languageInstruction = request.Language == "sv"
             ? "Respond in Swedish."
             : "Respond in English.";
+        var mode = request.Mode ?? "soft";
+
+        if (mode == "direct")
+        {
+            return $@"
+            {languageInstruction}
+            User question: {request.Question}
+
+            Cards drawn: {cardsText}
+
+            Provide a clear and direct tarot interpretation.
+
+            Tone and voice:
+            - Be clear and decisive
+            - Lean toward a strong interpretation rather than multiple possibilities
+            - Reduce hesitation and avoid soft qualifiers like ""maybe"" or ""perhaps""
+            - Speak directly and with quiet confidence
+            - You may point toward a likely direction, but do not frame it as certain or inevitable
+            - Do not dilute the message to make it more comfortable
+            - Avoid poetic or overly abstract language
+            - Keep the message focused and to the point
+            - Do not present the future as fixed or guaranteed
+            - Avoid absolute or deterministic claims
+
+            Structure:
+            - Keep the response concise (max 120 words)
+            - Write in plain text
+            - Do not use markdown, bullet points, or symbols
+            - Use short paragraphs
+            - Give a clear interpretation first, then end with one sharp reflective question
+            - Focus on what is actually happening in the situation rather than explaining the cards
+            - Adapt wording to the number of cards drawn
+
+            Card interpretation:
+            - When multiple cards are drawn, identify the dominant direction or tension between them
+            - Treat the cards as parts of a single situation rather than separate meanings
+            - Make the overall direction feel clear and grounded
+            - Do not soften conflicting signals unnecessarily
+
+            Card count guidance:
+            - For 2 cards, make the contrast or relationship between them clear
+            - For 3 cards, show progression: what shaped the situation, what is happening now, and where things are heading
+            - Keep the progression clear without labeling it explicitly
+            ";
+        }
 
         return $@"
             {languageInstruction}

--- a/API/Services/Tarot/TarotService.cs
+++ b/API/Services/Tarot/TarotService.cs
@@ -53,6 +53,17 @@ public class TarotService
             - Keep the message focused and to the point
             - Do not present the future as fixed or guaranteed
             - Avoid absolute or deterministic claims
+            - Avoid phrasing things as advice from the card (do not say ""this card suggests"" or ""it encourages"")
+            - State the situation directly instead of describing it indirectly
+            - Prefer statements over guidance (less ""consider"", more ""this is"")
+            - If there is hesitation or avoidance, point it out clearly
+            - Speak as if you are pointing out something the user already knows but avoids
+            - Do not comfort the user unnecessarily
+            - If there is avoidance, hesitation, or self-deception, highlight it clearly but without judgment
+            - Use a slightly confronting tone, but remain grounded and calm
+            - Do not explain the cards, speak only about the situation
+            - Never name or refer to the cards explicitly
+            - Do not describe symbolic meanings, only describe the situation as if it is directly observed
 
             Structure:
             - Keep the response concise (max 120 words)
@@ -93,6 +104,8 @@ public class TarotService
             - Avoid excessive hedging such as ""maybe"", ""perhaps"", or ""it could be"" unless genuinely needed
             - Avoid generic opening phrases like ""It feels like"", ""This suggests"", or similar filler
             - Avoid repeating similar sentence structures
+            - Use natural, direct language instead of formal or abstract phrasing
+            - Prefer simple and concrete wording over complex descriptions
 
             Structure:
             - Keep the response concise (max 150 words)


### PR DESCRIPTION
This PR introduces support for two distinct interpretation modes in the tarot system: soft and direct.

The goal is to give users different perspectives when reflecting on their question.

Soft mode provides a more reflective and supportive interpretation, while direct mode offers a clearer and more confronting perspective.

---

### Changes

- Added optional `mode` field to `TarotInterpretRequest`
- Implemented mode handling in TarotService
- Introduced two distinct prompt styles:
  - Soft: reflective, open-ended, supportive
  - Direct: clear, concise, and slightly confronting
- Removed explicit card references in direct mode for a more immersive experience
- Improved language to be more natural and less formal

---

### Behavior

- Default mode is `soft` if no mode is provided
- `direct` mode produces shorter, more situation-focused responses
- Both modes use the same input (question + cards) but differ in tone and delivery

---

### Testing

Tested via Swagger:

- Verified default (soft) behavior when mode is omitted
- Verified distinct output differences between soft and direct
- Confirmed no card names are referenced in direct mode