### PR TITLE
feat(comment): move comment creation to API with DTO, validation and ownership

### DIFF
--- a/API/Controllers/Comment/CommentController.cs
+++ b/API/Controllers/Comment/CommentController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -7,6 +8,7 @@ using SarasBloggAPI.Data;
 using SarasBloggAPI.Services.Comment;
 using SarasBloggAPI.DTOs.Comment;
 using Microsoft.EntityFrameworkCore;
+using System.Text.RegularExpressions;
 
 namespace SarasBloggAPI.Controllers.Comment
 {
@@ -41,6 +43,18 @@ namespace SarasBloggAPI.Controllers.Comment
             ["user"] = 3
         };
 
+        private async Task TryAuthenticateCurrentRequestAsync()
+        {
+            if (User?.Identity?.IsAuthenticated == true)
+                return;
+
+            var result = await HttpContext.AuthenticateAsync();
+            if (result.Succeeded && result.Principal != null)
+            {
+                HttpContext.User = result.Principal;
+            }
+        }
+
         private static string? GetTopRole(IList<string> roles)
             => roles?.OrderBy(r => RoleRank.TryGetValue(r ?? "", out var i) ? i : 999).FirstOrDefault();
 
@@ -48,6 +62,7 @@ namespace SarasBloggAPI.Controllers.Comment
         {
             var name = c.Name;
             string? topRole = null;
+            var (ownedByCurrentUser, canDelete) = await ResolveCurrentUserCommentPermissionsAsync(c);
 
             if (!string.IsNullOrWhiteSpace(c.Email))
             {
@@ -73,8 +88,44 @@ namespace SarasBloggAPI.Controllers.Comment
                 Name = name ?? "",
                 Content = c.Content,
                 CreatedAt = c.CreatedAt,
-                TopRole = topRole
+                TopRole = topRole,
+                OwnedByCurrentUser = ownedByCurrentUser,
+                CanDelete = canDelete
             };
+        }
+
+        private async Task<(bool OwnedByCurrentUser, bool CanDelete)> ResolveCurrentUserCommentPermissionsAsync(Models.Comment comment)
+        {
+            var myId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrWhiteSpace(myId))
+                return (false, false);
+
+            ApplicationUser? me = null;
+            var ownedByCurrentUser = !string.IsNullOrWhiteSpace(comment.UserId)
+                && string.Equals(comment.UserId, myId, StringComparison.Ordinal);
+
+            if (!ownedByCurrentUser && !string.IsNullOrWhiteSpace(comment.Email))
+            {
+                me = await _userManager.FindByIdAsync(myId);
+                ownedByCurrentUser = string.Equals(comment.Email, me?.Email, StringComparison.OrdinalIgnoreCase);
+            }
+
+            var roles = User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList();
+            if (roles.Count == 0)
+            {
+                me ??= await _userManager.FindByIdAsync(myId);
+                roles = me != null ? (await _userManager.GetRolesAsync(me)).ToList() : new List<string>();
+            }
+
+            var canModerate = roles.Any(IsModeratorRole);
+            return (ownedByCurrentUser, ownedByCurrentUser || canModerate);
+        }
+
+        private static bool IsModeratorRole(string role)
+        {
+            return role.Equals("superuser", StringComparison.OrdinalIgnoreCase) ||
+                   role.Equals("admin", StringComparison.OrdinalIgnoreCase) ||
+                   role.Equals("superadmin", StringComparison.OrdinalIgnoreCase);
         }
 
         private async Task<(ApplicationUser? User, string? TopRole)> ResolveBestUserByEmailAsync(string email)
@@ -112,6 +163,30 @@ namespace SarasBloggAPI.Controllers.Comment
                 .ToListAsync();
         }
 
+        private static bool ContainsForbiddenPattern(string? value, IEnumerable<string> patterns)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            foreach (var pattern in patterns)
+            {
+                if (string.IsNullOrWhiteSpace(pattern))
+                    continue;
+
+                try
+                {
+                    if (Regex.IsMatch(value, pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                        return true;
+                }
+                catch
+                {
+                    // Ignore invalid stored patterns for compatibility with existing moderation data.
+                }
+            }
+
+            return false;
+        }
+
 
         // ===== Endpoints =====
 
@@ -122,6 +197,8 @@ namespace SarasBloggAPI.Controllers.Comment
         {
             try
             {
+                await TryAuthenticateCurrentRequestAsync();
+
                 var comments = await _commentManager.GetCommentsAsync();
                 var list = new List<CommentDto>(comments.Count);
                 foreach (var c in comments)
@@ -147,6 +224,8 @@ namespace SarasBloggAPI.Controllers.Comment
         {
             try
             {
+                await TryAuthenticateCurrentRequestAsync();
+
                 var all = await _commentManager.GetCommentsAsync();
                 var filtered = all.Where(c => c.BloggId == bloggId)
                                   .OrderBy(c => c.CreatedAt)
@@ -177,6 +256,8 @@ namespace SarasBloggAPI.Controllers.Comment
         [HttpGet("ById/{id:int}")]
         public async Task<ActionResult<CommentDto>> GetComment(int id)
         {
+            await TryAuthenticateCurrentRequestAsync();
+
             var c = await _commentManager.GetCommentAsync(id);
             if (c == null) return NotFound();
             var dto = await ToDtoAsync(c);
@@ -189,10 +270,71 @@ namespace SarasBloggAPI.Controllers.Comment
         // Skapa kommentar: tillåt anonym OCH inloggad
         [AllowAnonymous]
         [HttpPost]
-        public async Task<IActionResult> PostComment([FromBody] Models.Comment comment)
+        public async Task<ActionResult<CommentDto>> PostComment([FromBody] CommentCreateRequest request)
         {
             try
             {
+                await TryAuthenticateCurrentRequestAsync();
+
+                if (request == null)
+                    return BadRequest("Kommentaren saknar innehåll.");
+
+                if (request.BloggId <= 0)
+                    return BadRequest("Blogginlägg saknas.");
+
+                if (string.IsNullOrWhiteSpace(request.Content))
+                    return BadRequest("Kommentaren får inte vara tom.");
+
+                var bloggIsCommentable = await _db.Bloggs
+                    .AsNoTracking()
+                    .AnyAsync(b => b.Id == request.BloggId && !b.Hidden && b.LaunchDate <= DateTime.UtcNow);
+
+                if (!bloggIsCommentable)
+                    return NotFound("Blogginlägget hittades inte eller är inte öppet för kommentarer.");
+
+                var comment = new Models.Comment
+                {
+                    BloggId = request.BloggId,
+                    Content = request.Content.Trim(),
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                // Om inloggad: koppla e-post + *aktuellt* username
+                var myId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (!string.IsNullOrWhiteSpace(myId))
+                {
+                    comment.UserId = myId;
+
+                    var me = await _userManager.FindByIdAsync(myId);
+                    if (me != null)
+                    {
+                        comment.Email = me.Email;
+                        comment.Name = me.UserName ?? request.Name?.Trim() ?? string.Empty;
+                    }
+                    else
+                    {
+                        comment.Name = request.Name?.Trim() ?? string.Empty;
+                    }
+                }
+                else
+                {
+                    comment.UserId = null;
+                    comment.Email = null;
+                    comment.Name = string.IsNullOrWhiteSpace(request.Name)
+                        ? "Gäst"
+                        : request.Name.Trim();
+                }
+
+                if (string.IsNullOrWhiteSpace(comment.Name))
+                    comment.Name = "Gäst";
+
+                var forbidden = await GetForbiddenWordsAsync();
+                if (ContainsForbiddenPattern(comment.Content, forbidden))
+                    return BadRequest("Kommentaren innehåller otillåtet språk.");
+
+                if (ContainsForbiddenPattern(comment.Name, forbidden))
+                    return BadRequest("Namnet innehåller otillåtet språk.");
+
                 bool isNameSafe = await _contentSafetyService.IsContentSafeAsync(comment.Name);
                 bool isContentSafe = await _contentSafetyService.IsContentSafeAsync(comment.Content);
 
@@ -201,29 +343,8 @@ namespace SarasBloggAPI.Controllers.Comment
                 if (!isContentSafe)
                     return BadRequest("Kommentaren bedömdes som osäker och kan inte publiceras.");
 
-                // Om inloggad: koppla e-post + *aktuellt* username
-                var myId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-                if (!string.IsNullOrWhiteSpace(myId))
-                {
-                    // NYTT: koppla UserId (för cascade delete)
-                    comment.UserId = myId;
-
-                    var me = await _userManager.FindByIdAsync(myId);
-                    if (me != null)
-                    {
-                        comment.Email = me.Email;                     // ägarskap
-                        comment.Name = me.UserName ?? comment.Name;   // render-namn
-                    }
-                }
-                else
-                {
-                    // Anonym: se till att Email INTE råkar bli kvar från tidigare request
-                    comment.UserId = null;  // viktigt: lämna null för anonyma
-                    comment.Email = null;
-                }
-
                 await _commentManager.CreateCommentAsync(comment);
-                return Ok();
+                return Ok(await ToDtoAsync(comment));
             }
             catch
             {

--- a/API/DTOs/Comment/CommentCreateRequest.cs
+++ b/API/DTOs/Comment/CommentCreateRequest.cs
@@ -1,0 +1,9 @@
+namespace SarasBloggAPI.DTOs.Comment
+{
+    public class CommentCreateRequest
+    {
+        public int BloggId { get; set; }
+        public string? Name { get; set; }
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/API/DTOs/Comment/CommentDto.cs
+++ b/API/DTOs/Comment/CommentDto.cs
@@ -10,5 +10,7 @@
 
         // nytt: rollinformation för färg
         public string? TopRole { get; set; }
+        public bool OwnedByCurrentUser { get; set; }
+        public bool CanDelete { get; set; }
     }
 }

--- a/API/Services/Comment/ContentSafetyService.cs
+++ b/API/Services/Comment/ContentSafetyService.cs
@@ -14,7 +14,7 @@ namespace SarasBloggAPI.Services.Comment
             _client = client;
         }
 
-        public async Task<bool> IsContentSafeAsync(string content)
+        public virtual async Task<bool> IsContentSafeAsync(string content)
         {
             var url = $"https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key={_apiKey}";
 

--- a/APITests/Infrastructure/CustomWebApplicationFactory.cs
+++ b/APITests/Infrastructure/CustomWebApplicationFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.DataProtection;
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -6,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SarasBloggAPI.Data;
+using SarasBloggAPI.Services.Comment;
 using SarasBloggAPI.Services.Media;
 using APITests.TestHelpers;
 using Testcontainers.PostgreSql;
@@ -82,6 +84,24 @@ protected override void ConfigureWebHost(IWebHostBuilder builder)
         services.AddSingleton<IFileHelper, FakeFileHelper>();
 
         // --------------------------------------------------
+        // Avoid external Perspective API calls in tests
+        // --------------------------------------------------
+        services.RemoveAll<ContentSafetyService>();
+        services.AddSingleton<ContentSafetyService, AlwaysSafeContentSafetyService>();
+
+        // --------------------------------------------------
+        // Deterministic authentication for integration tests
+        // --------------------------------------------------
+        services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+            })
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName,
+                _ => { });
+
+        // --------------------------------------------------
         // Kör migrationer
         // --------------------------------------------------
         var sp = services.BuildServiceProvider();
@@ -102,5 +122,18 @@ protected override void ConfigureWebHost(IWebHostBuilder builder)
                 .GetAwaiter()
                 .GetResult();
         }
+    }
+}
+
+internal sealed class AlwaysSafeContentSafetyService : ContentSafetyService
+{
+    public AlwaysSafeContentSafetyService()
+        : base(new ConfigurationBuilder().Build(), new HttpClient())
+    {
+    }
+
+    public override Task<bool> IsContentSafeAsync(string content)
+    {
+        return Task.FromResult(true);
     }
 }

--- a/APITests/Integration/CommentCreationTests.cs
+++ b/APITests/Integration/CommentCreationTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using APITests.Infrastructure;
+using APITests.TestHelpers;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using SarasBloggAPI;
+using SarasBloggAPI.Data;
+using SarasBloggAPI.DTOs.Comment;
+using SarasBloggAPI.Models;
+
+namespace APITests.Integration;
+
+public class CommentCreationTests : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory<Program> _factory;
+
+    public CommentCreationTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Post_Comment_AllowsAnonymousCommentAndSetsServerFields()
+    {
+        await ResetCommentDataAsync();
+        var bloggId = await SeedBloggAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/comment", new CommentCreateRequest
+        {
+            BloggId = bloggId,
+            Name = "",
+            Content = "En anonym kommentar"
+        });
+
+        var dto = await response.Content.ReadFromJsonAsync<CommentDto>(JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(dto);
+        Assert.True(dto!.Id > 0);
+        Assert.Equal(bloggId, dto.BloggId);
+        Assert.Equal("Gäst", dto.Name);
+        Assert.Equal("En anonym kommentar", dto.Content);
+        Assert.False(dto.OwnedByCurrentUser);
+        Assert.False(dto.CanDelete);
+        Assert.True(DateTime.UtcNow - dto.CreatedAt < TimeSpan.FromMinutes(1));
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+        var stored = await db.Comments.FindAsync(dto.Id);
+        Assert.NotNull(stored);
+        Assert.Null(stored!.UserId);
+        Assert.Null(stored.Email);
+    }
+
+    [Fact]
+    public async Task Post_Comment_UsesAuthenticatedUserIdentity()
+    {
+        await ResetCommentDataAsync();
+        var bloggId = await SeedBloggAsync();
+        var user = await CreateUserAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, user.Id);
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserNameHeader, user.UserName);
+
+        var response = await client.PostAsJsonAsync("/api/comment", new CommentCreateRequest
+        {
+            BloggId = bloggId,
+            Name = "Spoofed Name",
+            Content = "En inloggad kommentar"
+        });
+
+        var dto = await response.Content.ReadFromJsonAsync<CommentDto>(JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(dto);
+        Assert.Equal(user.UserName, dto!.Name);
+        Assert.True(dto.OwnedByCurrentUser);
+        Assert.True(dto.CanDelete);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+        var stored = await db.Comments.FindAsync(dto.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(user.Id, stored!.UserId);
+        Assert.Equal(user.Email, stored.Email);
+    }
+
+    [Fact]
+    public async Task Post_Comment_RejectsForbiddenWords()
+    {
+        await ResetCommentDataAsync();
+        var bloggId = await SeedBloggAsync();
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+            db.ForbiddenWords.Add(new ForbiddenWord { WordPattern = "blockedword" });
+            await db.SaveChangesAsync();
+        }
+
+        var response = await _client.PostAsJsonAsync("/api/comment", new CommentCreateRequest
+        {
+            BloggId = bloggId,
+            Name = "Besökare",
+            Content = "Det här innehåller blockedword"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MyDbContext>();
+        Assert.Empty(verifyDb.Comments);
+    }
+
+    [Fact]
+    public async Task Post_Comment_RejectsHiddenAndFutureBloggs()
+    {
+        await ResetCommentDataAsync();
+        var hiddenId = await SeedBloggAsync(hidden: true);
+        var futureId = await SeedBloggAsync(launchDate: DateTime.UtcNow.AddDays(1));
+
+        var hiddenResponse = await _client.PostAsJsonAsync("/api/comment", new CommentCreateRequest
+        {
+            BloggId = hiddenId,
+            Name = "Besökare",
+            Content = "Kommentar till dolt inlägg"
+        });
+
+        var futureResponse = await _client.PostAsJsonAsync("/api/comment", new CommentCreateRequest
+        {
+            BloggId = futureId,
+            Name = "Besökare",
+            Content = "Kommentar till framtida inlägg"
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, hiddenResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, futureResponse.StatusCode);
+    }
+
+    private async Task ResetCommentDataAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+
+        db.Comments.RemoveRange(db.Comments);
+        db.ForbiddenWords.RemoveRange(db.ForbiddenWords);
+        db.BloggLikes.RemoveRange(db.BloggLikes);
+        db.BloggImages.RemoveRange(db.BloggImages);
+        db.Bloggs.RemoveRange(db.Bloggs);
+
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<int> SeedBloggAsync(bool hidden = false, DateTime? launchDate = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+
+        var blogg = new Blogg
+        {
+            Title = "Comment test blog",
+            Content = "<p>Comment test content</p>",
+            Author = "IntegrationTest",
+            LaunchDate = launchDate ?? DateTime.UtcNow.AddHours(-1),
+            Hidden = hidden,
+            IsArchived = false
+        };
+
+        db.Bloggs.Add(blogg);
+        await db.SaveChangesAsync();
+        return blogg.Id;
+    }
+
+    private async Task<ApplicationUser> CreateUserAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var suffix = Guid.NewGuid().ToString("N");
+        var user = new ApplicationUser
+        {
+            UserName = $"commenter-{suffix}",
+            Email = $"commenter-{suffix}@example.com",
+            EmailConfirmed = true
+        };
+
+        var result = await userManager.CreateAsync(user);
+        Assert.True(result.Succeeded, string.Join("; ", result.Errors.Select(e => e.Description)));
+
+        return user;
+    }
+}

--- a/APITests/TestHelpers/TestAuthHandler.cs
+++ b/APITests/TestHelpers/TestAuthHandler.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+
+namespace APITests.TestHelpers;
+
+public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "Test";
+    public const string UserIdHeader = "X-Test-UserId";
+    public const string UserNameHeader = "X-Test-UserName";
+    public const string RolesHeader = "X-Test-Roles";
+
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(UserIdHeader, out var userId) ||
+            string.IsNullOrWhiteSpace(userId))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var userName = Request.Headers.TryGetValue(UserNameHeader, out var userNameHeader)
+            ? userNameHeader.ToString()
+            : userId.ToString();
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new(ClaimTypes.Name, userName)
+        };
+
+        if (Request.Headers.TryGetValue(RolesHeader, out var rolesHeader))
+        {
+            claims.AddRange(rolesHeader.ToString()
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(role => new Claim(ClaimTypes.Role, role)));
+        }
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}


### PR DESCRIPTION
### Summary
Moves comment creation fully into the API layer.

### What was done
- Introduced `CommentCreateRequest` DTO
- API now owns:
  - Validation
  - CreatedAt (UTC)
  - User identity resolution (claims)
  - Ownership flags (`OwnedByCurrentUser`, `CanDelete`)
- Added content safety checks before persistence
- Prevents commenting on:
  - Missing posts
  - Hidden posts
  - Future posts

### Compatibility
- Existing Razor frontend continues to work (same payload shape)
- No breaking changes to API contract

### Tests
- Integration tests added for comment creation flow
- All tests passing

### Notes
- Step 2 of write-contract refactor
- Frontend still consumes API as before