### PR TITLE
Feature/remove blog legacy

### DIFF
--- a/API/Controllers/Blogg/BloggController.cs
+++ b/API/Controllers/Blogg/BloggController.cs
@@ -21,12 +21,14 @@ namespace SarasBloggAPI.Controllers.Blogg
         private readonly BloggManager _BloggManager;
         private readonly BlogPostService _blogPostService;
         private readonly MyDbContext _db;
+        private readonly ILogger<BloggController> _logger;
 
-        public BloggController(BloggManager bloggManager, BlogPostService blogPostService, MyDbContext db)
+        public BloggController(BloggManager bloggManager, BlogPostService blogPostService, MyDbContext db, ILogger<BloggController> logger)
         {
             _BloggManager = bloggManager;
             _blogPostService = blogPostService;
             _db = db;
+            _logger = logger;
         }
 
         // GET: api/blogg
@@ -111,6 +113,10 @@ namespace SarasBloggAPI.Controllers.Blogg
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] BlogPostWriteRequest request)
         {
+            _logger.LogInformation(
+                "Create blog - Source={Source}",
+                request.GetLegacyId().HasValue ? "Legacy" : "DTO"
+            );
             var created = await _blogPostService.CreateAsync(request, User);
             return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
         }
@@ -120,6 +126,11 @@ namespace SarasBloggAPI.Controllers.Blogg
         [HttpPut("{id}")]
         public async Task<IActionResult> Update(int id, [FromBody] BlogPostWriteRequest request)
         {
+            _logger.LogInformation(
+                "Update blog - RouteId={RouteId}, Source={Source}",
+                id,
+                request.GetLegacyId().HasValue ? "Legacy" : "DTO"
+            );
             var legacyId = request.GetLegacyId();
             if (legacyId.HasValue && id != legacyId.Value)
                 return BadRequest();

--- a/API/Controllers/Blogg/BloggController.cs
+++ b/API/Controllers/Blogg/BloggController.cs
@@ -113,10 +113,13 @@ namespace SarasBloggAPI.Controllers.Blogg
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] BlogPostWriteRequest request)
         {
-            _logger.LogInformation(
-                "Create blog - Source={Source}",
-                request.GetLegacyId().HasValue ? "Legacy" : "DTO"
-            );
+            if (request == null)
+                return BadRequest("Blogginlägg saknas.");
+
+            if (string.IsNullOrWhiteSpace(request.Content))
+                return BadRequest("Blogginlägget saknar innehåll.");
+
+            _logger.LogInformation("Create blog - Source={Source}", "DTO");
             var created = await _blogPostService.CreateAsync(request, User);
             return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
         }
@@ -126,14 +129,17 @@ namespace SarasBloggAPI.Controllers.Blogg
         [HttpPut("{id}")]
         public async Task<IActionResult> Update(int id, [FromBody] BlogPostWriteRequest request)
         {
+            if (request == null)
+                return BadRequest("Blogginlägg saknas.");
+
+            if (string.IsNullOrWhiteSpace(request.Content))
+                return BadRequest("Blogginlägget saknar innehåll.");
+
             _logger.LogInformation(
                 "Update blog - RouteId={RouteId}, Source={Source}",
                 id,
-                request.GetLegacyId().HasValue ? "Legacy" : "DTO"
+                "DTO"
             );
-            var legacyId = request.GetLegacyId();
-            if (legacyId.HasValue && id != legacyId.Value)
-                return BadRequest();
 
             var updated = await _blogPostService.UpdateAsync(id, request, User);
             return updated != null ? NoContent() : NotFound();

--- a/API/Controllers/Comment/CommentController.cs
+++ b/API/Controllers/Comment/CommentController.cs
@@ -20,17 +20,20 @@ namespace SarasBloggAPI.Controllers.Comment
         private readonly ContentSafetyService _contentSafetyService;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly MyDbContext _db;
+        private readonly ILogger<CommentController> _logger;
 
         public CommentController(
             CommentManager commentManager,
             ContentSafetyService contentSafetyService,
             UserManager<ApplicationUser> userManager,
-            MyDbContext db)
+            MyDbContext db,
+            ILogger<CommentController> logger)
         {
             _commentManager = commentManager;
             _contentSafetyService = contentSafetyService;
             _userManager = userManager;
             _db = db;
+            _logger = logger;
         }
 
         // ===== Helpers =====
@@ -274,6 +277,10 @@ namespace SarasBloggAPI.Controllers.Comment
         {
             try
             {
+                _logger.LogInformation(
+                    "Create comment - Source={Source}",
+                    User?.Identity?.IsAuthenticated == true ? "Authenticated" : "Anonymous"
+                );
                 await TryAuthenticateCurrentRequestAsync();
 
                 if (request == null)
@@ -359,6 +366,11 @@ namespace SarasBloggAPI.Controllers.Comment
         [HttpDelete("ById/{id:int}")]
         public async Task<IActionResult> DeleteComment(int id)
         {
+            _logger.LogInformation(
+                "Delete comment - Id={Id}, User={UserId}",
+                id,
+                User?.FindFirstValue(ClaimTypes.NameIdentifier)
+            );
             var existing = await _commentManager.GetCommentAsync(id);
             if (existing == null) return NotFound();
 

--- a/API/Controllers/Comment/CommentController.cs
+++ b/API/Controllers/Comment/CommentController.cs
@@ -277,11 +277,12 @@ namespace SarasBloggAPI.Controllers.Comment
         {
             try
             {
+                await TryAuthenticateCurrentRequestAsync();
+
                 _logger.LogInformation(
                     "Create comment - Source={Source}",
                     User?.Identity?.IsAuthenticated == true ? "Authenticated" : "Anonymous"
                 );
-                await TryAuthenticateCurrentRequestAsync();
 
                 if (request == null)
                     return BadRequest("Kommentaren saknar innehåll.");
@@ -306,22 +307,16 @@ namespace SarasBloggAPI.Controllers.Comment
                     CreatedAt = DateTime.UtcNow
                 };
 
-                // Om inloggad: koppla e-post + *aktuellt* username
                 var myId = User.FindFirstValue(ClaimTypes.NameIdentifier);
                 if (!string.IsNullOrWhiteSpace(myId))
                 {
                     comment.UserId = myId;
+                    comment.Email = null;
 
                     var me = await _userManager.FindByIdAsync(myId);
-                    if (me != null)
-                    {
-                        comment.Email = me.Email;
-                        comment.Name = me.UserName ?? request.Name?.Trim() ?? string.Empty;
-                    }
-                    else
-                    {
-                        comment.Name = request.Name?.Trim() ?? string.Empty;
-                    }
+                    comment.Name = me?.UserName
+                        ?? User.Identity?.Name
+                        ?? string.Empty;
                 }
                 else
                 {

--- a/API/DTOs/Blogg/BlogPostWriteRequest.cs
+++ b/API/DTOs/Blogg/BlogPostWriteRequest.cs
@@ -1,56 +1,19 @@
-using System.Text.Json;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace SarasBloggAPI.DTOs.Blogg
 {
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public class BlogPostWriteRequest
     {
         public string? Title { get; set; }
-        public string Content { get; set; } = string.Empty;
+
+        [Required]
+        public string? Content { get; set; }
+
         public string? Author { get; set; }
         public DateTime? LaunchDateLocal { get; set; }
         public bool Hidden { get; set; }
         public bool IsArchived { get; set; }
-
-        [JsonExtensionData]
-        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
-
-        public int? GetLegacyId()
-        {
-            return TryGetExtension("id", out var value) && value.ValueKind == JsonValueKind.Number
-                && value.TryGetInt32(out var id)
-                    ? id
-                    : null;
-        }
-
-        public DateTime? GetLegacyLaunchDate()
-        {
-            if (!TryGetExtension("launchDate", out var value))
-                return null;
-
-            if (value.ValueKind == JsonValueKind.String && value.TryGetDateTime(out var date))
-                return date;
-
-            return null;
-        }
-
-        private bool TryGetExtension(string name, out JsonElement value)
-        {
-            value = default;
-
-            if (ExtensionData == null)
-                return false;
-
-            foreach (var item in ExtensionData)
-            {
-                if (string.Equals(item.Key, name, StringComparison.OrdinalIgnoreCase))
-                {
-                    value = item.Value;
-                    return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/API/DTOs/Comment/CommentCreateRequest.cs
+++ b/API/DTOs/Comment/CommentCreateRequest.cs
@@ -1,9 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
 namespace SarasBloggAPI.DTOs.Comment
 {
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public class CommentCreateRequest
     {
+        [Range(1, int.MaxValue)]
         public int BloggId { get; set; }
+
         public string? Name { get; set; }
-        public string Content { get; set; } = string.Empty;
+
+        [Required]
+        public string? Content { get; set; }
     }
 }

--- a/API/Services/Blogg/BlogPostService.cs
+++ b/API/Services/Blogg/BlogPostService.cs
@@ -88,21 +88,7 @@ namespace SarasBloggAPI.Services.Blogg
                 return TimeZoneInfo.ConvertTimeToUtc(local, SwedishZone);
             }
 
-            var legacyLaunchDate = request.GetLegacyLaunchDate();
-            if (legacyLaunchDate.HasValue)
-                return NormalizeLegacyUtc(legacyLaunchDate.Value);
-
             return DateTime.UtcNow;
-        }
-
-        private static DateTime NormalizeLegacyUtc(DateTime value)
-        {
-            return value.Kind switch
-            {
-                DateTimeKind.Utc => value,
-                DateTimeKind.Local => value.ToUniversalTime(),
-                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
-            };
         }
 
         private static string ResolveTitle(string? title, string content)

--- a/APITests/Integration/BlogPostWriteTests.cs
+++ b/APITests/Integration/BlogPostWriteTests.cs
@@ -121,7 +121,7 @@ public class BlogPostWriteTests : IClassFixture<CustomWebApplicationFactory<Prog
     }
 
     [Fact]
-    public async Task Post_Blogg_IgnoresLegacyOwnershipAndViewCountFields()
+    public async Task Post_Blogg_RejectsLegacyWriteFields()
     {
         await ResetBlogDataAsync();
         var client = CreateAdminClient(userId: "actual-owner", userName: "ActualOwner");
@@ -138,13 +138,11 @@ public class BlogPostWriteTests : IClassFixture<CustomWebApplicationFactory<Prog
             viewCount = 999
         });
 
-        var created = await response.Content.ReadFromJsonAsync<Blogg>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.NotNull(created);
-        Assert.Equal("actual-owner", created!.UserId);
-        Assert.Equal(0, created.ViewCount);
-        Assert.Equal(new DateTime(2026, 1, 15, 8, 30, 0), created.LaunchDate);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+        Assert.Empty(db.Bloggs);
     }
 
     private HttpClient CreateAdminClient(string userId = "admin-user", string userName = "Admin")

--- a/APITests/Integration/CommentCreationTests.cs
+++ b/APITests/Integration/CommentCreationTests.cs
@@ -88,7 +88,30 @@ public class CommentCreationTests : IClassFixture<CustomWebApplicationFactory<Pr
         var stored = await db.Comments.FindAsync(dto.Id);
         Assert.NotNull(stored);
         Assert.Equal(user.Id, stored!.UserId);
-        Assert.Equal(user.Email, stored.Email);
+        Assert.Null(stored.Email);
+    }
+
+    [Fact]
+    public async Task Post_Comment_RejectsLegacyWriteFields()
+    {
+        await ResetCommentDataAsync();
+        var bloggId = await SeedBloggAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/comment", new
+        {
+            id = 123,
+            bloggId,
+            name = "Besökare",
+            email = "legacy@example.com",
+            content = "Legacy shaped comment",
+            createdAt = DateTime.UtcNow
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+        Assert.Empty(db.Comments);
     }
 
     [Fact]

--- a/Frontend/DAL/BloggAPIManager.cs
+++ b/Frontend/DAL/BloggAPIManager.cs
@@ -8,6 +8,9 @@ namespace SarasBlogg.DAL
     public class BloggAPIManager
     {
         private readonly HttpClient _httpClient;
+        private static readonly TimeZoneInfo SwedishZone =
+            TimeZoneInfo.FindSystemTimeZoneById("Europe/Stockholm");
+
         private static readonly JsonSerializerOptions _jsonOpts = new()
         {
             PropertyNameCaseInsensitive = true,
@@ -39,7 +42,8 @@ namespace SarasBlogg.DAL
 
         public async Task<Blogg?> SaveBloggAsync(Blogg blogg)
         {
-            var content = new StringContent(JsonSerializer.Serialize(blogg, _jsonOpts), Encoding.UTF8, "application/json");
+            var payload = ToWriteRequest(blogg);
+            var content = new StringContent(JsonSerializer.Serialize(payload, _jsonOpts), Encoding.UTF8, "application/json");
             var resp = await _httpClient.PostAsync("api/Blogg", content);
             if (!resp.IsSuccessStatusCode) return null;
 
@@ -49,8 +53,37 @@ namespace SarasBlogg.DAL
 
         public async Task UpdateBloggAsync(Blogg blogg)
         {
-            var content = new StringContent(JsonSerializer.Serialize(blogg, _jsonOpts), Encoding.UTF8, "application/json");
+            var payload = ToWriteRequest(blogg);
+            var content = new StringContent(JsonSerializer.Serialize(payload, _jsonOpts), Encoding.UTF8, "application/json");
             await _httpClient.PutAsync($"api/Blogg/{blogg.Id}", content);
+        }
+
+        private static BlogPostWriteRequest ToWriteRequest(Blogg blogg)
+        {
+            return new BlogPostWriteRequest
+            {
+                Title = blogg.Title,
+                Content = blogg.Content ?? string.Empty,
+                Author = blogg.Author,
+                LaunchDateLocal = ToLaunchDateLocal(blogg.LaunchDate),
+                Hidden = blogg.Hidden,
+                IsArchived = blogg.IsArchived
+            };
+        }
+
+        private static DateTime? ToLaunchDateLocal(DateTime launchDate)
+        {
+            if (launchDate == default)
+                return null;
+
+            var local = launchDate.Kind switch
+            {
+                DateTimeKind.Utc => TimeZoneInfo.ConvertTimeFromUtc(launchDate, SwedishZone),
+                DateTimeKind.Local => TimeZoneInfo.ConvertTime(launchDate, SwedishZone),
+                _ => launchDate
+            };
+
+            return DateTime.SpecifyKind(local, DateTimeKind.Unspecified);
         }
 
         public async Task<bool> ToggleHiddenAsync(int id)

--- a/Frontend/DAL/CommentAPIManager.cs
+++ b/Frontend/DAL/CommentAPIManager.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using SarasBlogg.DTOs;
 
 namespace SarasBlogg.DAL
 {
@@ -10,7 +12,8 @@ namespace SarasBlogg.DAL
         private static readonly JsonSerializerOptions _jsonOpts = new()
         {
             PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
         public CommentAPIManager(HttpClient httpClient)
@@ -85,7 +88,14 @@ namespace SarasBlogg.DAL
 
         public async Task<string?> SaveCommentAsync(Models.Comment comment)
         {
-            var content = new StringContent(JsonSerializer.Serialize(comment), Encoding.UTF8, "application/json");
+            var request = new CommentCreateRequest
+            {
+                BloggId = comment.BloggId,
+                Name = string.IsNullOrWhiteSpace(comment.Name) ? null : comment.Name.Trim(),
+                Content = comment.Content ?? string.Empty
+            };
+
+            var content = new StringContent(JsonSerializer.Serialize(request, _jsonOpts), Encoding.UTF8, "application/json");
             var resp = await _httpClient.PostAsync("api/Comment", content);
 
             if (resp.IsSuccessStatusCode) return null;

--- a/Frontend/DTOs/BlogPostWriteRequest.cs
+++ b/Frontend/DTOs/BlogPostWriteRequest.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace SarasBlogg.DTOs
+{
+    public class BlogPostWriteRequest
+    {
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+
+        [JsonPropertyName("author")]
+        public string? Author { get; set; }
+
+        [JsonPropertyName("launchDateLocal")]
+        public DateTime? LaunchDateLocal { get; set; }
+
+        [JsonPropertyName("hidden")]
+        public bool Hidden { get; set; }
+
+        [JsonPropertyName("isArchived")]
+        public bool IsArchived { get; set; }
+    }
+}

--- a/Frontend/DTOs/CommentCreateRequest.cs
+++ b/Frontend/DTOs/CommentCreateRequest.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace SarasBlogg.DTOs
+{
+    public class CommentCreateRequest
+    {
+        [JsonPropertyName("bloggId")]
+        public int BloggId { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/Frontend/Models/Comment.cs
+++ b/Frontend/Models/Comment.cs
@@ -11,7 +11,6 @@ namespace SarasBlogg.Models
 
         [JsonPropertyName("name")]
         [DisplayName("Namn*")]
-        [Required(ErrorMessage = "Du behöver ange ett namn")]
         public string? Name { get; set; }
 
         [JsonPropertyName("email")]

--- a/Frontend/Pages/Shared/BloggBasePageModel.cs
+++ b/Frontend/Pages/Shared/BloggBasePageModel.cs
@@ -210,41 +210,18 @@ namespace SarasBlogg.Pages.Shared
                 }
             }
 
-            // 2) Inloggad? Tvinga namn+ev. e-post
-            if (IsAuth)
+            if (postedComment.Id == null)
             {
-                postedComment.Name = CurrentUserName;
+                if (IsAuth)
+                    postedComment.Name = null;
 
-                var email = CurrentUserEmail;
-                if (string.IsNullOrWhiteSpace(email) && !string.IsNullOrWhiteSpace(CurrentUserName))
-                {
-                    var (apiEmail, _) = await GetApiUserByNameAsync(CurrentUserName);
-                    email = apiEmail ?? "";
-                }
-                postedComment.Email = email;
-
-                // rensa ModelState så overrides går igenom
                 ModelState.Remove("ViewModel.Comment.Name");
                 ModelState.Remove("Comment.Name");
                 ModelState.Remove("ViewModel.Comment.Email");
                 ModelState.Remove("Comment.Email");
             }
 
-            // 3) UTC-tid för nya kommentarer
-            if (postedComment.Id == null)
-                postedComment.CreatedAt = DateTime.UtcNow;
-
-            // 3b) Anonymt namn: normalisera bara (valfritt)
-            if (!IsAuth && postedComment.Id == null)
-            {
-                var proposed = (postedComment.Name ?? "").Trim();
-                if (string.IsNullOrWhiteSpace(proposed)) proposed = "Gäst";
-                postedComment.Name = proposed;
-                ModelState.Remove("ViewModel.Comment.Name");
-                ModelState.Remove("Comment.Name");
-            }
-
-            // 4) Validera + spara
+            // 2) Validera + spara
             if (ModelState.IsValid && postedComment.Id == null)
             {
                 string errorMessage = await _bloggService.SaveCommentAsync(postedComment);
@@ -273,7 +250,7 @@ namespace SarasBlogg.Pages.Shared
                 return Page();
             }
 
-            // 5) Tillbaka till samma inlägg
+            // 3) Tillbaka till samma inlägg
             return RedirectToPage(pageName: null, pageHandler: null,
                 routeValues: new { showId = postedComment.BloggId, openComments = true }, fragment: "comments");
 

--- a/Frontend/Pages/Shared/_BloggList.cshtml
+++ b/Frontend/Pages/Shared/_BloggList.cshtml
@@ -427,9 +427,6 @@
 									<strong class="ms-1"><span class="@Model.RoleCss">@User.Identity.Name</span></strong>
 									<span class="badge bg-success ms-2 align-middle">inloggad</span>
 								</div>
-								<input type="hidden" asp-for="Comment.Name" value="@User.Identity.Name" />
-								<input type="hidden" asp-for="Comment.Email"
-									   value="@(User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value ?? User.FindFirst("email")?.Value)" />
 							}
 							else
 							{

--- a/Frontend/Services/BloggService.cs
+++ b/Frontend/Services/BloggService.cs
@@ -13,7 +13,6 @@ namespace SarasBlogg.Services
 
         private readonly BloggAPIManager _bloggApi;
         private readonly CommentAPIManager _commentApi;
-        private readonly ForbiddenWordAPIManager _forbiddenWordApi;
         private readonly BloggImageAPIManager _imageApi;
         private readonly IMemoryCache _cache;
         private readonly ILogger<BloggService> _logger;
@@ -22,14 +21,12 @@ namespace SarasBlogg.Services
             BloggAPIManager bloggApi,
             CommentAPIManager commentApi,
             IMemoryCache cache,
-            ForbiddenWordAPIManager forbiddenWordApi,
             BloggImageAPIManager imageApi,
             ILogger<BloggService> logger)
         {
             _bloggApi = bloggApi;
             _commentApi = commentApi;
             _cache = cache;
-            _forbiddenWordApi = forbiddenWordApi;
             _imageApi = imageApi;
             _logger = logger;
         }
@@ -212,21 +209,9 @@ namespace SarasBlogg.Services
             if (comment is null)
                 return "Ogiltig kommentar.";
 
-            // Normalisera fält så vi slipper NRE
             comment.Content ??= string.Empty;
-            comment.Name ??= string.Empty;
 
-            var forbidden = await _forbiddenWordApi.GetForbiddenPatternsAsync();
-
-            foreach (var p in forbidden)
-            {
-                if (comment.Content.ContainsForbiddenWord(p))
-                    return "Kommentaren innehåller otillåtet språk.";
-                if (comment.Name.ContainsForbiddenWord(p))
-                    return "Namnet innehåller otillåtet språk.";
-            }
-
-            return await _commentApi.SaveCommentAsync(comment);
+            return await _commentApi.SaveCommentAsync(comment) ?? string.Empty;
         }
 
 


### PR DESCRIPTION
## 🧹 Refactor: Remove legacy write support & complete API-first alignment

### Summary

This PR completes the transition to an API-first architecture by:

- Aligning Razor frontend with DTO-based contracts  
- Removing frontend-owned business logic  
- Eliminating legacy payload support in the API  

The system now enforces a single, explicit contract for blog and comment writes.

---

## 🔧 What changed

### ✅ Frontend alignment

Blog and comment creation/update now use DTOs exclusively:

- `BlogPostWriteRequest`  
- `CommentCreateRequest`  

Removed from frontend:

- Sending database-shaped models (`Blogg`, `Comment`)  
- Manual setting of:  
  - `UserId`  
  - `Email`  
  - `CreatedAt`  
  - `ViewCount`  
- Fallback logic (`"Gäst"`, title generation)  
- Forbidden word checks (now API-owned)  
- Legacy field names (`launchDate`, etc.)  

Frontend now acts purely as a data sender.

---

### 🧠 Backend cleanup (legacy removal)

Removed all legacy compatibility logic:

- `GetLegacyId()`  
- `GetLegacyLaunchDate()`  
- `JsonExtensionData`  
- Any fallback mapping from old payloads  

API now:

- Accepts only strict DTOs  
- Rejects legacy payloads with `400 BadRequest`  
- Fully owns:  
  - Identity (`UserId` from claims)  
  - Timestamps (`CreatedAt`)  
  - Validation & moderation  
  - Fallback values  

---

### 🔒 Contract enforcement

- Unknown or legacy fields (e.g. `id`, `email`, `viewCount`) now fail validation  
- Controllers no longer inspect or trust client-owned fields  
- Service layer is deterministic and DTO-driven  

---

### 🧪 Tests

- Updated integration tests to reflect strict DTO usage  
- Added expectations that legacy payloads fail  
- All tests passing  

---

## 🎯 Result

The system is now:

- Fully API-driven for write operations  
- Frontend-agnostic (ready for Svelte/mobile)  
- Free from legacy fallback paths  
- Based on a single, stable contract  

---

## ⚠️ Notes / follow-up (non-blocking)

- ViewCount is still frontend-triggered → should move to dedicated API endpoint  
- Some UI-level validation still exists in Razor (cosmetic only)  
- Contact/spam handling can be moved to API in future  

---

## ✅ Verification

- Blog create/update logs:  
  - `Create blog - Source=DTO`  
  - `Update blog - Source=DTO`  

- Comment logs:  
  - `Create comment - Source=Authenticated`  
  - `Create comment - Source=Anonymous`  

- Legacy payloads now return `400 BadRequest`  

---

## 🚀 Impact

This PR finalizes the migration to a clean API-first architecture and removes technical debt related to legacy payload handling.