### PR TITLE
Refactor: Remove Frontend-Owned Logic and Legacy Cleanup

### DIFF
--- a/API/Controllers/Blogg/BloggController.cs
+++ b/API/Controllers/Blogg/BloggController.cs
@@ -93,10 +93,10 @@ namespace SarasBloggAPI.Controllers.Blogg
                 bloggId = candidates.FirstOrDefault(b => CreateTitleSlug(b.Title) == requestedSlug)?.Id;
             }
 
-            if (!bloggId.HasValue)
+            if (bloggId is not int resolvedBloggId)
                 return NotFound();
 
-            var blogg = await IncrementViewCountAndReloadAsync(bloggId.Value, archive, includeImages: true);
+            var blogg = await IncrementViewCountAndReloadAsync(resolvedBloggId);
             if (blogg == null)
                 return NotFound();
 

--- a/API/Controllers/Blogg/BloggController.cs
+++ b/API/Controllers/Blogg/BloggController.cs
@@ -73,11 +73,14 @@ namespace SarasBloggAPI.Controllers.Blogg
         public async Task<ActionResult<BlogPostDetailDto>> GetPublicByIdOrSlug(string idOrSlug, [FromQuery] bool archive = false)
         {
             var query = PublicBloggsQuery(DateTime.UtcNow, archive);
-            BloggModel? blogg = null;
+            int? bloggId = null;
 
             if (TryGetId(idOrSlug, out var id))
             {
-                blogg = await query.FirstOrDefaultAsync(b => b.Id == id);
+                bloggId = await query
+                    .Where(b => b.Id == id)
+                    .Select(b => (int?)b.Id)
+                    .FirstOrDefaultAsync();
             }
             else
             {
@@ -87,9 +90,13 @@ namespace SarasBloggAPI.Controllers.Blogg
                     .ThenByDescending(b => b.Id)
                     .ToListAsync();
 
-                blogg = candidates.FirstOrDefault(b => CreateTitleSlug(b.Title) == requestedSlug);
+                bloggId = candidates.FirstOrDefault(b => CreateTitleSlug(b.Title) == requestedSlug)?.Id;
             }
 
+            if (!bloggId.HasValue)
+                return NotFound();
+
+            var blogg = await IncrementViewCountAndReloadAsync(bloggId.Value, archive, includeImages: true);
             if (blogg == null)
                 return NotFound();
 
@@ -101,7 +108,7 @@ namespace SarasBloggAPI.Controllers.Blogg
         [HttpGet("{id}")]
         public async Task<ActionResult<BloggModel>> Get(int id)
         {
-            var blogg = await _BloggManager.GetByIdAsync(id);
+            var blogg = await IncrementViewCountAndReloadAsync(id);
             if (blogg == null)
                 return NotFound();
 
@@ -183,6 +190,31 @@ namespace SarasBloggAPI.Controllers.Blogg
                 .AsNoTracking()
                 .Include(b => b.Images)
                 .Where(b => !b.Hidden && b.LaunchDate <= nowUtc && b.IsArchived == archive);
+        }
+
+        private async Task<BloggModel?> IncrementViewCountAndReloadAsync(int id, bool? archive = null, bool includeImages = false)
+        {
+            var nowUtc = DateTime.UtcNow;
+            IQueryable<BloggModel> query = _db.Bloggs;
+
+            if (includeImages)
+            {
+                query = query.Include(b => b.Images);
+            }
+
+            if (archive.HasValue)
+            {
+                query = query.Where(b => !b.Hidden && b.LaunchDate <= nowUtc && b.IsArchived == archive.Value);
+            }
+
+            var blogg = await query.FirstOrDefaultAsync(b => b.Id == id);
+
+            if (blogg == null)
+                return null;
+
+            blogg.ViewCount += 1;
+            await _db.SaveChangesAsync();
+            return blogg;
         }
 
         private static BlogPostSummaryDto ToSummaryDto(BloggModel blogg)

--- a/API/Controllers/Blogg/BloggController.cs
+++ b/API/Controllers/Blogg/BloggController.cs
@@ -93,10 +93,10 @@ namespace SarasBloggAPI.Controllers.Blogg
                 bloggId = candidates.FirstOrDefault(b => CreateTitleSlug(b.Title) == requestedSlug)?.Id;
             }
 
-            if (bloggId is not int resolvedBloggId)
+            if (!bloggId.HasValue)
                 return NotFound();
 
-            var blogg = await IncrementViewCountAndReloadAsync(resolvedBloggId);
+            var blogg = await IncrementViewCountAndReloadAsync(bloggId.Value, archive, includeImages: true);
             if (blogg == null)
                 return NotFound();
 

--- a/API/DAL/BloggManager.cs
+++ b/API/DAL/BloggManager.cs
@@ -23,7 +23,9 @@ namespace SarasBloggAPI.DAL
 
         public async Task<List<Blogg>> GetAllAsync()
         {
-            return await _context.Bloggs.OrderByDescending(b => b.LaunchDate)
+            return await _context.Bloggs
+                .AsNoTracking()
+                .OrderByDescending(b => b.LaunchDate)
                 .ThenByDescending(b => b.Id).ToListAsync();
         }
 

--- a/APITests/Integration/BloggTests.cs
+++ b/APITests/Integration/BloggTests.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
 using SarasBloggAPI;
 using SarasBloggAPI.Data;
 using SarasBloggAPI.Models;
@@ -123,6 +124,103 @@ public class BloggTests
             method: "GET"
         );
     }
+
+    [Fact]
+    public async Task Get_BloggById_IncrementsViewCountAndReturnsUpdatedValue()
+    {
+        await ResetBlogDataAsync();
+
+        int bloggId;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+
+            var blogg = new Blogg
+            {
+                Title = "View count test",
+                Content = "Integration test content",
+                Author = "IntegrationTest",
+                LaunchDate = DateTime.UtcNow,
+                IsArchived = false,
+                Hidden = false,
+                ViewCount = 7
+            };
+
+            db.Bloggs.Add(blogg);
+            await db.SaveChangesAsync();
+
+            bloggId = blogg.Id;
+        }
+
+        var endpoint = $"/api/blogg/{bloggId}";
+
+        var firstResponse = await _client.GetAsync(endpoint);
+        var first = await firstResponse.Content.ReadFromJsonAsync<Blogg>();
+
+        var secondResponse = await _client.GetAsync(endpoint);
+        var second = await secondResponse.Content.ReadFromJsonAsync<Blogg>();
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(8, first!.ViewCount);
+        Assert.Equal(9, second!.ViewCount);
+
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MyDbContext>();
+        var storedViewCount = await verifyDb.Bloggs
+            .AsNoTracking()
+            .Where(b => b.Id == bloggId)
+            .Select(b => b.ViewCount)
+            .SingleAsync();
+
+        Assert.Equal(9, storedViewCount);
+    }
+
+    [Fact]
+    public async Task Get_Bloggs_ReturnsUpdatedViewCountAfterDetailRead()
+    {
+        await ResetBlogDataAsync();
+
+        int bloggId;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+
+            var blogg = new Blogg
+            {
+                Title = "List view count test",
+                Content = "Integration test content",
+                Author = "IntegrationTest",
+                LaunchDate = DateTime.UtcNow,
+                IsArchived = false,
+                Hidden = false,
+                ViewCount = 39
+            };
+
+            db.Bloggs.Add(blogg);
+            await db.SaveChangesAsync();
+
+            bloggId = blogg.Id;
+        }
+
+        var detailResponse = await _client.GetAsync($"/api/blogg/{bloggId}");
+        var detail = await detailResponse.Content.ReadFromJsonAsync<Blogg>();
+
+        var listResponse = await _client.GetAsync("/api/blogg");
+        var list = await listResponse.Content.ReadFromJsonAsync<List<Blogg>>();
+
+        Assert.Equal(HttpStatusCode.OK, detailResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        Assert.NotNull(detail);
+        Assert.NotNull(list);
+        Assert.Equal(40, detail!.ViewCount);
+        Assert.Equal(40, Assert.Single(list!, b => b.Id == bloggId).ViewCount);
+    }
+
     [Fact]
     public async Task Post_Blogg_Returns401_WhenAnonymous()
     {
@@ -156,6 +254,8 @@ public class BloggTests
     [Fact]
     public async Task Get_Bloggs_ReturnsEmptyList_WhenDatabaseIsEmpty()
     {
+        await ResetBlogDataAsync();
+
         // Arrange
         var endpoint = "/api/blogg";
         var expectedStatusCode = HttpStatusCode.OK;
@@ -178,5 +278,18 @@ public class BloggTests
             endpoint,
             method: "GET"
         );
+    }
+
+    private async Task ResetBlogDataAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+
+        db.BloggLikes.RemoveRange(db.BloggLikes);
+        db.Comments.RemoveRange(db.Comments);
+        db.BloggImages.RemoveRange(db.BloggImages);
+        db.Bloggs.RemoveRange(db.Bloggs);
+
+        await db.SaveChangesAsync();
     }
 }

--- a/APITests/Integration/PublicBloggTests.cs
+++ b/APITests/Integration/PublicBloggTests.cs
@@ -89,10 +89,21 @@ public class PublicBloggTests : IClassFixture<CustomWebApplicationFactory<Progra
         Assert.NotNull(detail);
         Assert.Equal("Latest public", detail!.Title);
         Assert.Equal("<p>Latest public content</p>", detail.Content);
+        Assert.Equal(1, detail.ViewCount);
         Assert.Equal("/uploads/blogg/latest-cover-first.jpg", detail.CoverImage?.FilePath);
         Assert.Equal(
             new[] { "/uploads/blogg/latest-cover-first.jpg", "/uploads/blogg/latest-cover-second.jpg" },
             detail.Images.Select(i => i.FilePath));
+
+        var secondDetail = await _client.GetFromJsonAsync<BlogPostDetailDto>($"/api/blogg/public/{slug}", JsonOptions);
+
+        Assert.NotNull(secondDetail);
+        Assert.Equal(2, secondDetail!.ViewCount);
+
+        var refreshedList = await _client.GetFromJsonAsync<BlogPostListDto>("/api/blogg/public?page=1&pageSize=10", JsonOptions);
+
+        Assert.NotNull(refreshedList);
+        Assert.Equal(2, Assert.Single(refreshedList!.Items, i => i.Title == "Latest public").ViewCount);
     }
 
     [Fact]

--- a/Frontend/DAL/CommentAPIManager.cs
+++ b/Frontend/DAL/CommentAPIManager.cs
@@ -52,21 +52,7 @@ namespace SarasBlogg.DAL
             return JsonSerializer.Deserialize<DTOs.CommentWithRoleDto>(json, _jsonOpts);
         }
 
-        // --- Bakåtkompatibla metoder (mappar DTO -> gamla modellen) ---
-
-        public async Task<List<Models.Comment>> GetAllCommentsAsync()
-        {
-            var dtos = await GetAllCommentsWithRolesAsync();
-            return dtos.Select(d => new Models.Comment
-            {
-                Id = d.Id,
-                BloggId = d.BloggId,
-                Name = d.Name,
-                Email = null,              // Exponeras ej publikt
-                Content = d.Content ?? "",
-                CreatedAt = d.CreatedAt
-            }).ToList();
-        }
+        // --- Bakåtkompatibel metod (mappar DTO -> gamla modellen) ---
 
         public async Task<Models.Comment?> GetCommentAsync(int id)
         {

--- a/Frontend/DAL/ForbiddenWordAPIManager.cs
+++ b/Frontend/DAL/ForbiddenWordAPIManager.cs
@@ -26,12 +26,6 @@ namespace SarasBlogg.DAL
             return JsonSerializer.Deserialize<List<ForbiddenWord>>(json, _jsonOpts) ?? new();
         }
 
-        public async Task<List<string>> GetForbiddenPatternsAsync()
-        {
-            var forbiddenWords = await GetAllAsync();
-            return forbiddenWords.Select(f => f.WordPattern).ToList();
-        }
-
         public async Task<ForbiddenWord?> GetByIdAsync(int id)
         {
             var resp = await _httpClient.GetAsync($"api/ForbiddenWord/{id}");

--- a/Frontend/Extensions/RegexExtensions.cs
+++ b/Frontend/Extensions/RegexExtensions.cs
@@ -4,13 +4,6 @@ namespace SarasBlogg.Extensions
 {
     public static class RegexExtensions
     {
-        public static bool ContainsForbiddenWord(this string input, string pattern)
-        {
-            if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(pattern))
-                return false;
-
-            return Regex.IsMatch(input, pattern, RegexOptions.IgnoreCase);
-        }
         public static string ToRegexPattern(this string word)
         {
             if (string.IsNullOrWhiteSpace(word))

--- a/Frontend/Pages/Admin/Index.cshtml.cs
+++ b/Frontend/Pages/Admin/Index.cshtml.cs
@@ -59,7 +59,6 @@ namespace SarasBlogg.Pages.Admin
             if ((IsAdmin || IsSuperAdmin) && hiddenId is int hid and > 0)
             {
                 await _bloggApi.ToggleHiddenAsync(hid);
-                _bloggService.InvalidateBlogListCache();
                 return RedirectToPage();
             }
 
@@ -67,7 +66,6 @@ namespace SarasBlogg.Pages.Admin
             if ((IsAdmin || IsSuperAdmin) && archiveId is int aid and > 0)
             {
                 await _bloggApi.ToggleArchivedAsync(aid);
-                _bloggService.InvalidateBlogListCache();
                 return RedirectToPage();
             }
 
@@ -175,8 +173,6 @@ namespace SarasBlogg.Pages.Admin
                 }
             }
 
-            _bloggService.InvalidateBlogListCache();
-
             if (uploadErrors.Count > 0)
                 TempData["UploadErrors"] = string.Join("\n", uploadErrors);
 
@@ -194,7 +190,6 @@ namespace SarasBlogg.Pages.Admin
                 await _commentApi.DeleteCommentsAsync(bloggToDelete.Id);
                 await _imageApi.DeleteImagesByBloggIdAsync(bloggToDelete.Id);
                 await _bloggApi.DeleteBloggAsync(bloggToDelete.Id);
-                _bloggService.InvalidateBlogListCache();
             }
 
             return RedirectToPage();
@@ -214,7 +209,6 @@ namespace SarasBlogg.Pages.Admin
                 images.Insert(0, imageToSet);
 
                 await _imageApi.UpdateImageOrderAsync(bloggId, images);
-                _bloggService.InvalidateBlogListCache();
             }
 
             return RedirectToPage(new { editId = bloggId });
@@ -225,7 +219,6 @@ namespace SarasBlogg.Pages.Admin
         {
             if (!User.IsInRole("superadmin")) return Forbid();
             await _imageApi.DeleteImageAsync(imageId);
-            _bloggService.InvalidateBlogListCache();
 
             return RedirectToPage(new { editId = bloggId });
         }

--- a/Frontend/Pages/Admin/Index.cshtml.cs
+++ b/Frontend/Pages/Admin/Index.cshtml.cs
@@ -1,10 +1,8 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SarasBlogg.DAL;
 using SarasBlogg.DTOs;
-using SarasBlogg.Helpers;
 using SarasBlogg.Models;
 using SarasBlogg.Extensions; // ToSwedishTime (används i listan)
 using SarasBlogg.Services;   // BloggService för cache-invalidering
@@ -135,18 +133,8 @@ namespace SarasBlogg.Pages.Admin
             var uploadErrors = new List<string>();
             var currentBlogg = await _bloggApi.GetBloggAsync(NewBlogg.Id);
 
-            NewBlogg.UserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-            var localDate = DateTime.SpecifyKind(NewBlogg.LaunchDate.Date, DateTimeKind.Unspecified);
-            var utcDate = TimeZoneInfo.ConvertTimeToUtc(localDate, TzSe);
-            NewBlogg.LaunchDate = utcDate;
-
             if (NewBlogg.Id == 0)
             {
-                NewBlogg.Title = string.IsNullOrWhiteSpace(NewBlogg.Title)
-                    ? BloggTextHelper.GenerateFallbackTitle(NewBlogg.Content)
-                    : NewBlogg.Title;
-
                 var savedBlogg = await _bloggApi.SaveBloggAsync(NewBlogg);
                 if (savedBlogg == null)
                 {
@@ -163,13 +151,10 @@ namespace SarasBlogg.Pages.Admin
                 if (currentBlogg == null)
                     return NotFound();
 
-                currentBlogg.Title     = string.IsNullOrWhiteSpace(NewBlogg.Title)
-                    ? BloggTextHelper.GenerateFallbackTitle(NewBlogg.Content)
-                    : NewBlogg.Title;
+                currentBlogg.Title     = NewBlogg.Title;
                 currentBlogg.Content   = NewBlogg.Content;
                 currentBlogg.Author    = NewBlogg.Author;
                 currentBlogg.LaunchDate = NewBlogg.LaunchDate;
-                currentBlogg.UserId    = NewBlogg.UserId;
 
                 await _bloggApi.UpdateBloggAsync(currentBlogg);
             }

--- a/Frontend/Pages/Admin/Index.cshtml.cs
+++ b/Frontend/Pages/Admin/Index.cshtml.cs
@@ -2,10 +2,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SarasBlogg.DAL;
-using SarasBlogg.DTOs;
 using SarasBlogg.Models;
 using SarasBlogg.Extensions; // ToSwedishTime (används i listan)
-using SarasBlogg.Services;   // BloggService för cache-invalidering
 
 namespace SarasBlogg.Pages.Admin
 {
@@ -17,21 +15,16 @@ namespace SarasBlogg.Pages.Admin
         private readonly BloggImageAPIManager _imageApi;
         private readonly CommentAPIManager _commentApi;
 
-        // Cache-tjänst (publik listcache)
-        private readonly BloggService _bloggService;
-
         private static readonly TimeZoneInfo TzSe = TimeZoneInfo.FindSystemTimeZoneById("Europe/Stockholm");
 
         public IndexModel(
             BloggAPIManager bloggApi,
             BloggImageAPIManager imageApi,
-            CommentAPIManager commentApi,
-            BloggService bloggService)
+            CommentAPIManager commentApi)
         {
             _bloggApi = bloggApi;
             _imageApi = imageApi;
             _commentApi = commentApi;
-            _bloggService = bloggService;
         }
 
         public List<BloggWithImage> BloggsWithImage { get; set; } = new();

--- a/Frontend/Pages/Blogg.cshtml.cs
+++ b/Frontend/Pages/Blogg.cshtml.cs
@@ -159,8 +159,6 @@ namespace SarasBlogg.Pages
                 }
             }
 
-            _bloggService.InvalidateBlogListCache();
-
             if (uploadErrors.Count > 0)
                 TempData["UploadErrors"] = string.Join("\n", uploadErrors);
 
@@ -181,7 +179,6 @@ namespace SarasBlogg.Pages
                 images.Insert(0, imageToSet);
 
                 await _imageApi.UpdateImageOrderAsync(bloggId, images);
-                _bloggService.InvalidateBlogListCache();
             }
 
             return RedirectToPage(new { editId = bloggId });
@@ -192,7 +189,6 @@ namespace SarasBlogg.Pages
         {
             if (!User.IsInRole("superadmin")) return Forbid();
             await _imageApi.DeleteImageAsync(imageId);
-            _bloggService.InvalidateBlogListCache();
 
             return RedirectToPage(new { editId = bloggId });
         }

--- a/Frontend/Pages/Blogg.cshtml.cs
+++ b/Frontend/Pages/Blogg.cshtml.cs
@@ -1,8 +1,6 @@
-﻿using System.Security.Claims;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using SarasBlogg.Services;
 using SarasBlogg.DAL;
-using SarasBlogg.Helpers;
 using SarasBlogg.Models;
 using SarasBlogg.Pages.Shared;
 
@@ -119,18 +117,8 @@ namespace SarasBlogg.Pages
             var uploadErrors = new List<string>();
             var currentBlogg = await _bloggApi.GetBloggAsync(NewBlogg.Id);
 
-            NewBlogg.UserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-            var localDate = DateTime.SpecifyKind(NewBlogg.LaunchDate.Date, DateTimeKind.Unspecified);
-            var utcDate = TimeZoneInfo.ConvertTimeToUtc(localDate, TzSe);
-            NewBlogg.LaunchDate = utcDate;
-
             if (NewBlogg.Id == 0)
             {
-                NewBlogg.Title = string.IsNullOrWhiteSpace(NewBlogg.Title)
-                    ? BloggTextHelper.GenerateFallbackTitle(NewBlogg.Content)
-                    : NewBlogg.Title;
-
                 var savedBlogg = await _bloggApi.SaveBloggAsync(NewBlogg);
                 if (savedBlogg == null)
                 {
@@ -147,13 +135,10 @@ namespace SarasBlogg.Pages
                 if (currentBlogg == null)
                     return NotFound();
 
-                currentBlogg.Title = string.IsNullOrWhiteSpace(NewBlogg.Title)
-                    ? BloggTextHelper.GenerateFallbackTitle(NewBlogg.Content)
-                    : NewBlogg.Title;
+                currentBlogg.Title = NewBlogg.Title;
                 currentBlogg.Content = NewBlogg.Content;
                 currentBlogg.Author = NewBlogg.Author;
                 currentBlogg.LaunchDate = NewBlogg.LaunchDate;
-                currentBlogg.UserId = NewBlogg.UserId;
 
                 await _bloggApi.UpdateBloggAsync(currentBlogg);
             }

--- a/Frontend/Pages/Contact.cshtml.cs
+++ b/Frontend/Pages/Contact.cshtml.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
 using SarasBlogg.DAL;
-using SarasBlogg.Extensions; // f�r visning i vyer (ToSwedishTime)
 
 namespace SarasBlogg.Pages
 {

--- a/Frontend/Pages/Shared/BloggBasePageModel.cs
+++ b/Frontend/Pages/Shared/BloggBasePageModel.cs
@@ -108,9 +108,6 @@ namespace SarasBlogg.Pages.Shared
 
         public async Task OnGetCoreAsync(int showId, int id, bool openComments)
         {
-            if (showId != 0)
-                await _bloggService.UpdateViewCountAsync(showId);
-
             ViewModel = await _bloggService.GetBloggViewModelAsync(_isArchive, showId);
             ViewModel.Comment ??= new Models.Comment();
             Comment = ViewModel.Comment;

--- a/Frontend/Pages/Shared/BloggBasePageModel.cs
+++ b/Frontend/Pages/Shared/BloggBasePageModel.cs
@@ -6,7 +6,6 @@ using SarasBlogg.DAL;
 using System.Security.Claims;
 using SarasBlogg.DTOs;
 using Microsoft.Extensions.DependencyInjection;
-using Humanizer;
 
 namespace SarasBlogg.Pages.Shared
 {

--- a/Frontend/Pages/Shared/BloggBasePageModel.cs
+++ b/Frontend/Pages/Shared/BloggBasePageModel.cs
@@ -105,40 +105,6 @@ namespace SarasBlogg.Pages.Shared
         }
 
         protected bool IsAuth => User?.Identity?.IsAuthenticated == true;
-        protected string CurrentUserName => IsAuth ? (User?.Identity?.Name ?? "") : "";
-        protected string CurrentUserEmail =>
-            IsAuth
-                ? (User.FindFirst(ClaimTypes.Email)?.Value
-                   ?? User.FindFirst("email")?.Value
-                   ?? "")
-                : "";
-
-        protected static bool HasAdminLikeRole(IEnumerable<string> roles) =>
-            roles.Any(r => string.Equals(r, "superadmin", StringComparison.OrdinalIgnoreCase)
-                        || string.Equals(r, "admin", StringComparison.OrdinalIgnoreCase)
-                        || string.Equals(r, "superuser", StringComparison.OrdinalIgnoreCase));
-
-        // PROD-fallback: hämta email/roller via API om cookies saknar claims
-        protected async Task<(string? Email, List<string> Roles)> GetApiUserByNameAsync(string userNameOrEmail)
-        {
-            try
-            {
-                var all = await _userApi.GetAllUsersAsync();
-                var u = all?.FirstOrDefault(x =>
-                    (!string.IsNullOrWhiteSpace(x.UserName) && !string.IsNullOrWhiteSpace(userNameOrEmail) &&
-                     string.Equals(x.UserName, userNameOrEmail, StringComparison.OrdinalIgnoreCase))
-                    ||
-                    (!string.IsNullOrWhiteSpace(x.Email) && !string.IsNullOrWhiteSpace(userNameOrEmail) &&
-                     string.Equals(x.Email, userNameOrEmail, StringComparison.OrdinalIgnoreCase))
-                );
-
-                return (u?.Email, (u?.Roles ?? Enumerable.Empty<string>()).ToList());
-            }
-            catch
-            {
-                return (null, new List<string>());
-            }
-        }
 
         public async Task OnGetCoreAsync(int showId, int id, bool openComments)
         {
@@ -176,38 +142,17 @@ namespace SarasBlogg.Pages.Shared
 
             var postedComment = Comment ?? new Models.Comment();
 
-            // 1) Delete (admin eller ägare via namn/e-post)
+            // 1) Delete. API owns authorization and ownership checks.
             if (deleteCommentId != 0)
             {
                 var existing = await _bloggService.GetCommentAsync(deleteCommentId);
+                await _bloggService.DeleteCommentAsync(deleteCommentId);
+
                 if (existing != null)
-                {
-                    var isAdmin = User.IsInRole("superadmin") || User.IsInRole("admin") || User.IsInRole("superuser");
-                    if (!isAdmin && IsAuth && !string.IsNullOrWhiteSpace(CurrentUserName))
-                    {
-                        var (_, roles) = await GetApiUserByNameAsync(CurrentUserName);
-                        if (HasAdminLikeRole(roles)) isAdmin = true;
-                    }
-
-                    var isOwner =
-                        (!string.IsNullOrWhiteSpace(existing.Name) && !string.IsNullOrWhiteSpace(CurrentUserName) &&
-                         string.Equals(existing.Name, CurrentUserName, StringComparison.OrdinalIgnoreCase))
-                        ||
-                        (!string.IsNullOrWhiteSpace(existing.Email) && !string.IsNullOrWhiteSpace(CurrentUserEmail) &&
-                         string.Equals(existing.Email, CurrentUserEmail, StringComparison.OrdinalIgnoreCase));
-
-                    if (!isAdmin && !isOwner)
-                    {
-                        TempData["Error"] = "Du får inte ta bort denna kommentar.";
-                        return RedirectToPage(pageName: null, pageHandler: null,
-                            routeValues: new { showId = existing.BloggId, openComments = true }, fragment: "comments");
-                    }
-
-                    await _bloggService.DeleteCommentAsync(deleteCommentId);
-                    TempData["Info"] = "Kommentar borttagen.";
                     return RedirectToPage(pageName: null, pageHandler: null,
                         routeValues: new { showId = existing.BloggId, openComments = true }, fragment: "comments");
-                }
+
+                return RedirectToPage(pageName: null, pageHandler: null, routeValues: null, fragment: "comments");
             }
 
             if (postedComment.Id == null)

--- a/Frontend/Program.cs
+++ b/Frontend/Program.cs
@@ -1,19 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.DataProtection;
+﻿using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using SarasBlogg.DAL;
 using SarasBlogg.Services;
-using Npgsql.EntityFrameworkCore.PostgreSQL;
 using Microsoft.AspNetCore.HttpOverrides;
 using Polly;
 using Polly.Extensions.Http;
-using System.Net.Http;
-using System.IO;
-using Microsoft.Extensions.Options;
-using Microsoft.AspNetCore.Authentication;
 using SarasBlogg.Infrastructure;
-using Microsoft.AspNetCore.Mvc;
-
 
 namespace SarasBlogg
 {
@@ -155,16 +147,6 @@ namespace SarasBlogg
             builder.Services.AddScoped<IAccessTokenStore, CookieAccessTokenStore>();
             
             builder.Services.AddTransient<JwtAuthHandler>();
-
-            // 🟨 Originalregistreringar — behållna men utkommenterade nedan:
-            // builder.Services.AddScoped<BloggAPIManager>();
-            // builder.Services.AddHttpClient<BloggImageAPIManager>();
-            // builder.Services.AddScoped<CommentAPIManager>();
-            // builder.Services.AddScoped<ForbiddenWordAPIManager>();
-            // builder.Services.AddScoped<AboutMeAPIManager>();
-            // builder.Services.AddHttpClient<AboutMeImageAPIManager>();
-            // builder.Services.AddScoped<ContactMeAPIManager>();
-            // builder.Services.AddSingleton<UserAPIManager>();
 
             // 🔹 API base URL från konfig (dev: appsettings.Development.json, prod: env ApiSettings__BaseAddress)
             var apiBase = builder.Configuration["ApiSettings:BaseAddress"]

--- a/Frontend/Services/BloggService.cs
+++ b/Frontend/Services/BloggService.cs
@@ -83,7 +83,6 @@ namespace SarasBlogg.Services
             }
 
             vm.RoleCssByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            vm.VerifiedCommentIds ??= new HashSet<int>(); // säkra init
 
             if (vm.Blogg is not null && vm.Blogg.Id != 0)
             {
@@ -104,9 +103,6 @@ namespace SarasBlogg.Services
                     var css = MapTopRoleToCss(d.TopRole);
                     if (!string.IsNullOrEmpty(css))
                         vm.RoleCssByName[d.Name] = css;
-
-                    if (!string.IsNullOrWhiteSpace(d.TopRole))
-                        vm.VerifiedCommentIds.Add(d.Id);
                 }
             }
             else
@@ -128,9 +124,6 @@ namespace SarasBlogg.Services
                     var css = MapTopRoleToCss(d.TopRole);
                     if (!string.IsNullOrEmpty(css))
                         vm.RoleCssByName[d.Name] = css;
-
-                    if (!string.IsNullOrWhiteSpace(d.TopRole))
-                        vm.VerifiedCommentIds.Add(d.Id);
                 }
             }
 

--- a/Frontend/Services/BloggService.cs
+++ b/Frontend/Services/BloggService.cs
@@ -2,37 +2,33 @@
 using SarasBlogg.Models;
 using SarasBlogg.Extensions;
 using SarasBlogg.DAL;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace SarasBlogg.Services
 {
     public class BloggService
     {
-        private const string CacheKeyAll = "blogg:list:all";
-
         private readonly BloggAPIManager _bloggApi;
         private readonly CommentAPIManager _commentApi;
         private readonly BloggImageAPIManager _imageApi;
-        private readonly IMemoryCache _cache;
         private readonly ILogger<BloggService> _logger;
 
         public BloggService(
             BloggAPIManager bloggApi,
             CommentAPIManager commentApi,
-            IMemoryCache cache,
             BloggImageAPIManager imageApi,
             ILogger<BloggService> logger)
         {
             _bloggApi = bloggApi;
             _commentApi = commentApi;
-            _cache = cache;
             _imageApi = imageApi;
             _logger = logger;
         }
 
-        /// <summary>Invalidera listcachen så att publika listor uppdateras direkt efter admin-ändringar.</summary>
-        public void InvalidateBlogListCache() => _cache.Remove(CacheKeyAll);
+        public void InvalidateBlogListCache()
+        {
+            // Blog lists are intentionally uncached so ViewCount stays in sync after detail reads.
+        }
 
         private static string MapTopRoleToCss(string? top) => top?.ToLower() switch
         {
@@ -53,7 +49,7 @@ namespace SarasBlogg.Services
             // Svensk "nu"-tid för filtrering/sortering
             var nowSe = DateTime.UtcNow.ToSwedishTime();
 
-            // Hämta alla (cache) och filtrera lokalt
+            // Hämta alla färskt från API:t och filtrera lokalt
             var all = await GetAllBloggsAsync(includeArchived: true);
 
             vm.Bloggs = all
@@ -72,16 +68,22 @@ namespace SarasBlogg.Services
 
             if (showId != 0)
             {
-                var blogg = vm.Bloggs.FirstOrDefault(b => b.Id == showId);
-                if (blogg == null)
+                var blogg = await _bloggApi.GetBloggAsync(showId);
+                if (blogg != null)
                 {
-                    blogg = await _bloggApi.GetBloggAsync(showId);
-                    if (blogg != null)
+                    if (blogg.Images == null) await AttachImagesAsync(blogg);
+
+                    var existingIndex = vm.Bloggs.FindIndex(b => b.Id == showId);
+                    if (existingIndex >= 0)
                     {
-                        if (blogg.Images == null) await AttachImagesAsync(blogg);
+                        vm.Bloggs[existingIndex] = blogg;
+                    }
+                    else
+                    {
                         vm.Bloggs.Add(blogg);
                     }
                 }
+
                 vm.Blogg = blogg;
             }
 
@@ -140,50 +142,14 @@ namespace SarasBlogg.Services
             return vm;
         }
 
-        /// <summary>
-        /// Hämtar alla bloggar (IMemoryCache ~45s), filtrerar & laddar bilder för det som returneras.
-        /// Sätt bypassCache=true för att forcera färsk hämtning (t.ex. direkt efter admin-ändring).
-        /// </summary>
-        public async Task<List<Blogg>> GetAllBloggsAsync(bool includeArchived = false, bool bypassCache = false)
+        public async Task<List<Blogg>> GetAllBloggsAsync(bool includeArchived = false)
         {
-            if (bypassCache)
-            {
-                try { return await FetchAndFilterAsync(includeArchived); }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Bypass misslyckades, faller tillbaka på cache.");
-                }
-            }
+            var all = await FetchAndFilterAsync(includeArchived);
 
-            if (!_cache.TryGetValue(CacheKeyAll, out List<Blogg>? all))
-            {
-                try
-                {
-                    all = await _bloggApi.GetAllBloggsAsync(); // rå-lista utan filter
-                    _cache.Set(CacheKeyAll, all, new MemoryCacheEntryOptions
-                    {
-                        AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(45)
-                    });
-                }
-                catch (HttpRequestException ex)
-                {
-                    _logger.LogWarning(ex, "API-fel – visar ev. cache.");
-                }
-                catch (TaskCanceledException ex)
-                {
-                    _logger.LogWarning(ex, "API-timeout – visar ev. cache.");
-                }
-            }
-
-            all ??= new List<Blogg>();
-
-            var filtered = FilterClientSide(all, includeArchived);
-
-            // Attach:a bilder endast för de som faktiskt visas
-            foreach (var b in filtered)
+            foreach (var b in all)
                 if (b.Images == null) await AttachImagesAsync(b);
 
-            return filtered;
+            return all;
         }
 
         private static List<Blogg> FilterClientSide(IEnumerable<Blogg> all, bool includeArchived)
@@ -200,8 +166,21 @@ namespace SarasBlogg.Services
 
         private async Task<List<Blogg>> FetchAndFilterAsync(bool includeArchived)
         {
-            var all = await _bloggApi.GetAllBloggsAsync();
-            return FilterClientSide(all ?? Enumerable.Empty<Blogg>(), includeArchived);
+            try
+            {
+                var all = await _bloggApi.GetAllBloggsAsync();
+                return FilterClientSide(all ?? Enumerable.Empty<Blogg>(), includeArchived);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(ex, "API-fel vid hämtning av bloggar.");
+            }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogWarning(ex, "API-timeout vid hämtning av bloggar.");
+            }
+
+            return new List<Blogg>();
         }
 
         public async Task<string> SaveCommentAsync(Comment comment)
@@ -217,15 +196,5 @@ namespace SarasBlogg.Services
 
         public Task DeleteCommentAsync(int id) => _commentApi.DeleteCommentAsync(id);
         public Task<Comment?> GetCommentAsync(int id) => _commentApi.GetCommentAsync(id);
-
-        public async Task UpdateViewCountAsync(int bloggId)
-        {
-            var blogg = await _bloggApi.GetBloggAsync(bloggId);
-            if (blogg != null)
-            {
-                blogg.ViewCount++;
-                await _bloggApi.UpdateBloggAsync(blogg);
-            }
-        }
     }
 }

--- a/Frontend/Services/BloggService.cs
+++ b/Frontend/Services/BloggService.cs
@@ -25,11 +25,6 @@ namespace SarasBlogg.Services
             _logger = logger;
         }
 
-        public void InvalidateBlogListCache()
-        {
-            // Blog lists are intentionally uncached so ViewCount stays in sync after detail reads.
-        }
-
         private static string MapTopRoleToCss(string? top) => top?.ToLower() switch
         {
             "superadmin" => "role-superadmin",

--- a/Frontend/ViewModels/BloggViewModel.cs
+++ b/Frontend/ViewModels/BloggViewModel.cs
@@ -7,13 +7,8 @@
         public bool IsArchiveView { get; set; } = false;
         public List<Models.Comment>? Comments { get; set; }
         public Models.Comment? Comment { get; set; }
-        public string RoleSymbol { get; set; } = "";
         public string RoleCss { get; set; } = "";
-        public HashSet<int> VerifiedCommentIds { get; set; } = new();
 
-        // Extra dictionaries for role symbols and CSS classes
         public Dictionary<string, string> RoleCssByName { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-        //public Dictionary<string, string> RoleSymbolByName { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-
     }
 }


### PR DESCRIPTION
## Summary

This PR continues the API-first migration by removing frontend-owned business logic, legacy payload handling, stale caching behavior, and duplicated validation/moderation flows from the Razor frontend.

The goal was to make the frontend behave as a thin API client while moving ownership of business rules, write flows, validation, and data integrity fully into the backend.

This cleanup was done incrementally and verified continuously in the live Razor UI.

---

# What Changed

## Blog Write Flow Cleanup

Refactored blog create/update flows to use strict DTO-based API contracts instead of serializing legacy frontend models.

### Removed frontend-owned responsibilities
- Legacy payload fields (`id`, `userId`, `viewCount`, `launchDate`)
- Frontend ownership assignment
- Frontend launch date normalization for API persistence
- Frontend fallback title generation
- Frontend-side business-rule duplication

### Result
Frontend now behaves as a pure API consumer:
- Razor → DTO → API
- API owns persistence and write rules

---

## Comment Flow Cleanup

Refactored comment creation/deletion flows to remove duplicated frontend logic and legacy behavior.

### Removed
- Frontend forbidden-word validation duplication
- Frontend comment ownership checks
- Frontend comment fallback logic
- Legacy full-model comment payloads
- Legacy email/name round-tripping
- Obsolete comment mapping/helpers

### Result
Comment creation/deletion is now fully backend-driven while Razor only handles UI concerns.

---

## Legacy Payload Removal

Removed backend compatibility support for legacy blog/comment payloads.

### API now rejects old model-shaped requests containing:
- `id`
- `userId`
- `viewCount`
- `launchDate`
- `email`
- `createdAt`

### Result
Strict DTO contracts are now enforced consistently.

---

## ViewCount Refactor

ViewCount ownership was moved fully into the backend.

### Previous behavior
- Frontend triggered updates
- Frontend caching caused stale counts
- List/detail views could diverge

### New behavior
- `GET /api/blogg/{id}` increments ViewCount server-side
- Backend returns updated values directly
- Blog list now always fetches fresh data from API
- Frontend cache invalidation logic removed entirely

### Removed
- Frontend-triggered view updates
- `/view` frontend logic
- JavaScript-based view syncing
- `InvalidateBlogListCache()`
- IMemoryCache blog-list caching

### Result
ViewCount is now API-owned and consistent across detail/list pages.

---

## Frontend Dead-Code Cleanup

Removed obsolete frontend code left behind after the migration.

### Cleanup included
- Dead helper methods
- Obsolete moderation helpers
- Unused comment mapping logic
- Dead ViewModel bookkeeping
- Unused service methods
- Unused usings/comments
- Legacy cache invalidation remnants

### Important
This cleanup intentionally avoided:
- Razor form lifecycle changes
- Hidden field rewrites
- Editor/modal rewiring
- DTO changes
- API contract changes

---

# Verification

## Automated Verification
- `dotnet build Frontend/SarasBlogg.csproj`
- `dotnet build API/SarasBloggAPI.csproj`
- `dotnet build APITests/APITests.csproj`
- `dotnet test SarasBlogg-Workspace.sln`

All passing.

---

## Manual Razor Verification

Verified directly in the live Razor frontend:

### Blog Flow
- Create blog post
- Edit blog post
- Delete/hide blog post
- ViewCount updates correctly

### Comment Flow
- Create authenticated comment
- Create anonymous comment
- Delete comment

### Admin Flow
- Blog admin actions still function correctly

### Contact Flow
- Confirmed unchanged behavior

---

# Architectural Outcome

This PR significantly reduces frontend/backend coupling.

### Before
- Frontend contained duplicated business logic
- Legacy payload compatibility existed
- Frontend cache/state could diverge from backend truth
- Razor performed backend-owned responsibilities

### After
- API owns business rules and persistence
- Frontend acts as a thinner client
- DTO contracts are strict and explicit
- Backend is source of truth
- Legacy compatibility layers removed

---

# Notes

This PR intentionally keeps Razor-specific form lifecycle and editor wiring intact even where some duplication remains, since those flows are still tightly coupled to Razor page behavior.

The purpose of this PR was controlled cleanup and responsibility consolidation — not a full frontend rewrite.

---

# Commits Included

- `refactor(blog): remove frontend-owned blog logic`
- `refactor(comment): remove frontend business logic duplication`
- `chore(blog): remove unused cache invalidation logic`
- `chore(frontend): clean up dead legacy helpers and unused code`