### PR TITLE
chore(deploy): add GitHub Pages workflow for Svelte client

### DIFF
--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -11,6 +11,7 @@
 				"@eslint/compat": "^2.0.2",
 				"@eslint/js": "^9.39.2",
 				"@sveltejs/adapter-auto": "^7.0.0",
+				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.50.2",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@types/node": "^22",
@@ -1153,6 +1154,16 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-7.0.1.tgz",
 			"integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@sveltejs/kit": "^2.0.0"
+			}
+		},
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.10.tgz",
+			"integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/Client/package.json
+++ b/Client/package.json
@@ -17,6 +17,7 @@
 		"@eslint/compat": "^2.0.2",
 		"@eslint/js": "^9.39.2",
 		"@sveltejs/adapter-auto": "^7.0.0",
+		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@types/node": "^22",

--- a/Client/svelte.config.js
+++ b/Client/svelte.config.js
@@ -1,12 +1,23 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
+
+const dev = process.argv.includes('dev');
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter({
+			pages: 'build',
+			assets: 'build',
+			fallback: 'index.html'
+		}),
+
+		paths: {
+			base: dev ? '' : '/sarasblogg-workspace'
+		},
+
+		prerender: {
+			handleHttpError: 'warn'
+		}
 	}
 };
 


### PR DESCRIPTION
Summary

This PR adds automated GitHub Pages deployment support for the Svelte frontend client.

The SvelteKit app is now configured for static hosting and deployment through GitHub Actions while continuing to use the existing ASP.NET API backend as the source of truth.

Changes

SvelteKit static deployment setup

* Switched from adapter-auto to adapter-static
* Configured static build output to Client/build
* Added SPA fallback handling with index.html
* Added GitHub Pages base path configuration for repository deployment

GitHub Actions deployment workflow

Added:

* .github/workflows/deploy-svelte-client.yml

Workflow now:

* installs frontend dependencies
* builds the Svelte client
* injects VITE_API_BASE_URL
* uploads Pages artifact
* deploys automatically to GitHub Pages on push to main

Environment configuration

Uses GitHub Actions repository secret:

VITE_API_BASE_URL

pointing to the existing production API backend.

Architecture Notes

This keeps the current architecture intact:

* ASP.NET API remains the backend source of truth
* SvelteKit acts as a static API consumer
* Razor frontend remains unaffected
* No database/auth/business logic moved into frontend

Verification

Verified:

* npm run build
* static build generation
* GitHub Pages workflow configuration
* Pages artifact output path
* base path configuration for repository-hosted deployment