### PR TITLE
fix(svelte): use configured api base url in production

### DIFF
--- a/.github/workflows/deploy-svelte-client.yml
+++ b/.github/workflows/deploy-svelte-client.yml
@@ -33,6 +33,10 @@ jobs:
 
       - name: Build Client
         run: |
+          if [ -z "$VITE_API_BASE_URL" ]; then
+            echo "VITE_API_BASE_URL secret is required for the GitHub Pages Svelte build."
+            exit 1
+          fi
           cd Client
           npm run build
         env:

--- a/Client/src/lib/api/apiClient.ts
+++ b/Client/src/lib/api/apiClient.ts
@@ -1,4 +1,3 @@
-import { env } from '$env/dynamic/public';
 import { createApiError } from './apiErrors';
 
 export type ApiFetch = typeof fetch;
@@ -8,12 +7,32 @@ export type ApiRequestOptions = Omit<RequestInit, 'body'> & {
 	emptyResponse?: boolean;
 };
 
+const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL ?? '').trim();
+const missingApiBaseUrlMessage =
+	'Missing required VITE_API_BASE_URL. Production builds must set the API base URL, for example https://sarasbloggapi-backend.onrender.com.';
+
+function normalizeBaseUrl(url: string) {
+	return url.replace(/\/+$/, '');
+}
+
 export function getApiBaseUrl() {
-	return (env.PUBLIC_API_BASE_URL ?? '').replace(/\/$/, '');
+	if (apiBaseUrl) return normalizeBaseUrl(apiBaseUrl);
+
+	if (import.meta.env.PROD) {
+		throw new Error(missingApiBaseUrlMessage);
+	}
+
+	return '';
 }
 
 export function getExternalApiBaseUrl() {
-	return (env.PUBLIC_API_BASE_URL ?? 'https://localhost:5003').replace(/\/$/, '');
+	if (apiBaseUrl) return normalizeBaseUrl(apiBaseUrl);
+
+	if (import.meta.env.PROD) {
+		throw new Error(missingApiBaseUrlMessage);
+	}
+
+	return 'https://localhost:5003';
 }
 
 function resolveApiUrl(path: string) {

--- a/Client/vite.config.ts
+++ b/Client/vite.config.ts
@@ -1,15 +1,26 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 
-export default defineConfig({
-  plugins: [sveltekit()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'https://localhost:5003',
-        changeOrigin: true,
-        secure: false
-      }
-    }
-  }
+export default defineConfig(({ command, mode }) => {
+	const env = loadEnv(mode, process.cwd(), '');
+	const apiBaseUrl = env.VITE_API_BASE_URL?.trim();
+
+	if (command === 'build' && !apiBaseUrl) {
+		throw new Error(
+			'Missing required VITE_API_BASE_URL. Production builds must set it to the deployed API base URL, for example https://sarasbloggapi-backend.onrender.com.'
+		);
+	}
+
+	return {
+		plugins: [sveltekit()],
+		server: {
+			proxy: {
+				'/api': {
+					target: apiBaseUrl || 'https://localhost:5003',
+					changeOrigin: true,
+					secure: false
+				}
+			}
+		}
+	};
 });


### PR DESCRIPTION
Changed:


apiClient.ts (line 10) now reads import.meta.env.VITE_API_BASE_URL at build time.

Production client code now throws a clear config error if VITE_API_BASE_URL is missing, instead of falling back to relative /api.

Local dev still works with relative /api through the Vite proxy, defaulting to https://localhost:5003.

vite.config.ts (line 8) now fails production builds loudly when VITE_API_BASE_URL is missing.

deploy-svelte-client.yml (line 36) now explicitly checks the existing VITE_API_BASE_URL secret before npm run build.
