### PR TITLE
Fix GitHub Pages assets and add cookie consent UX

### DIFF
--- a/Client/src/lib/components/layout/CookieConsent.svelte
+++ b/Client/src/lib/components/layout/CookieConsent.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { onMount } from 'svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import Modal from '$lib/components/ui/Modal.svelte';
+
+	const consentStorageKey = 'sarasblogg.cookieConsent.v1';
+
+	let isBannerVisible = false;
+	let isPrivacyOpen = false;
+
+	onMount(() => {
+		isBannerVisible = !hasConsent();
+	});
+
+	function hasConsent() {
+		return browser && localStorage.getItem(consentStorageKey) === 'accepted';
+	}
+
+	function acceptConsent() {
+		if (browser) {
+			localStorage.setItem(consentStorageKey, 'accepted');
+		}
+		isBannerVisible = false;
+		isPrivacyOpen = false;
+	}
+
+	export function openPrivacy() {
+		isPrivacyOpen = true;
+	}
+
+	function closePrivacy() {
+		isPrivacyOpen = false;
+	}
+</script>
+
+{#if isBannerVisible}
+	<section class="cookie-banner" aria-labelledby="cookie-banner-title">
+		<div>
+			<p id="cookie-banner-title" class="cookie-banner__title">Vår cookie-policy</p>
+			<p>
+				Vi använder endast nödvändiga cookies och lokal lagring för att webbplatsen ska fungera
+				och komma ihåg dina val.
+			</p>
+		</div>
+		<div class="cookie-banner__actions">
+			<button type="button" class="text-button" on:click={openPrivacy}>Läs mer</button>
+			<Button type="button" on:click={acceptConsent}>Acceptera</Button>
+		</div>
+	</section>
+{/if}
+
+<Modal open={isPrivacyOpen} title="Integritet och cookies" on:close={closePrivacy}>
+	<div class="privacy-content">
+		<p>
+			På SarasBlogg värnar vi om din integritet. Vi sparar inga känsliga uppgifter och
+			samlar inte in mer data än vad som behövs för att webbplatsen ska fungera.
+		</p>
+
+		<h3>Cookies och lokal lagring</h3>
+		<p>
+			Vi använder nödvändiga cookies för inloggning och säker åtkomst. För cookie-bannern
+			sparas ditt val i webbläsarens lokala lagring så att du slipper se frågan igen.
+		</p>
+
+		<table>
+			<thead>
+				<tr>
+					<th>Namn</th>
+					<th>Syfte</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>{consentStorageKey}</td>
+					<td>Kommer ihåg att du accepterat cookieinformationen.</td>
+				</tr>
+				<tr>
+					<td>SarasAuth / api_access_token</td>
+					<td>Nödvändiga inloggnings- och åtkomstcookies när du loggar in.</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<h3>Dina val</h3>
+		<p>
+			Vi lägger inte till analysverktyg eller tredjepartsspårning här. Om du rensar
+			webbläsarens lagring visas bannern igen vid nästa besök.
+		</p>
+
+		<div class="privacy-content__actions">
+			<Button type="button" on:click={acceptConsent}>Acceptera</Button>
+			<Button type="button" variant="ghost" on:click={closePrivacy}>Stäng</Button>
+		</div>
+	</div>
+</Modal>
+
+<style>
+	.cookie-banner {
+		position: fixed;
+		right: 1rem;
+		bottom: 1rem;
+		left: 1rem;
+		z-index: 75;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		gap: 1rem;
+		align-items: center;
+		width: min(920px, calc(100vw - 2rem));
+		margin-inline: auto;
+		padding: 1rem;
+		border: 1px solid rgba(217, 155, 121, 0.5);
+		border-radius: var(--radius-card);
+		background: rgba(255, 250, 244, 0.96);
+		box-shadow: var(--shadow-soft);
+		backdrop-filter: blur(14px);
+	}
+
+	.cookie-banner__title {
+		margin: 0 0 0.25rem;
+		color: var(--color-heading);
+		font-family: var(--font-serif);
+		font-size: 1.55rem;
+		font-weight: 700;
+		line-height: 1.05;
+	}
+
+	.cookie-banner p {
+		margin: 0;
+		color: var(--color-muted);
+	}
+
+	.cookie-banner__actions,
+	.privacy-content__actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.65rem;
+		align-items: center;
+		justify-content: flex-end;
+	}
+
+	.text-button {
+		border: 0;
+		background: transparent;
+		color: #9f664f;
+		font-weight: 800;
+		text-decoration: underline;
+		text-underline-offset: 0.22em;
+	}
+
+	.privacy-content {
+		display: grid;
+		gap: 1rem;
+		color: var(--color-text);
+	}
+
+	.privacy-content p,
+	.privacy-content h3 {
+		margin: 0;
+	}
+
+	.privacy-content h3 {
+		color: var(--color-heading);
+		font-family: var(--font-serif);
+		font-size: 1.45rem;
+		line-height: 1.1;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		overflow: hidden;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-soft);
+	}
+
+	th,
+	td {
+		padding: 0.7rem 0.8rem;
+		border-bottom: 1px solid rgba(95, 74, 59, 0.1);
+		text-align: left;
+		vertical-align: top;
+	}
+
+	th {
+		color: var(--color-muted);
+		font-size: 0.76rem;
+		font-weight: 900;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+
+	tr:last-child td {
+		border-bottom: 0;
+	}
+
+	@media (max-width: 720px) {
+		.cookie-banner {
+			grid-template-columns: 1fr;
+		}
+
+		.cookie-banner__actions,
+		.privacy-content__actions {
+			justify-content: flex-start;
+		}
+	}
+</style>

--- a/Client/src/lib/components/layout/Footer.svelte
+++ b/Client/src/lib/components/layout/Footer.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import { brand } from '$lib/config/site';
 	import BrandLockup from '$lib/components/brand/BrandLockup.svelte';
 	import SocialLinks from '$lib/components/layout/SocialLinks.svelte';
 	import { routes } from '$lib/utils/routes';
+
+	const dispatch = createEventDispatcher<{ privacy: void }>();
 </script>
 
 <footer class="site-footer">
@@ -36,7 +39,7 @@
 
 	<div class="container footer-bottom">
 		<span>© 2026 {brand.name}</span>
-		<span>Integritet · Cookies</span>
+		<button type="button" on:click={() => dispatch('privacy')}>Integritet · Cookies</button>
 	</div>
 	<img class="footer-flower" src={brand.footerFlower} alt="" loading="lazy" />
 </footer>
@@ -141,6 +144,21 @@
 		border-top: 1px solid rgba(95, 74, 59, 0.09);
 		color: var(--color-muted);
 		font-size: 0.85rem;
+	}
+
+	.footer-bottom button {
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.footer-bottom button:hover {
+		color: var(--color-heading);
+		text-decoration: underline;
+		text-underline-offset: 0.22em;
 	}
 
 	@media (max-width: 860px) {

--- a/Client/src/routes/+layout.svelte
+++ b/Client/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '$lib/styles/global.css';
 	import Navbar from '$lib/components/layout/Navbar.svelte';
 	import Footer from '$lib/components/layout/Footer.svelte';
+	import CookieConsent from '$lib/components/layout/CookieConsent.svelte';
 	import Toast from '$lib/components/ui/Toast.svelte';
 	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte';
 	import { brand } from '$lib/config/site';
@@ -13,6 +14,7 @@
 	const topLeftFlower = staticAsset('/images/logo/top-left-corner-flower-ny.png');
 	const bottomRightFlower = staticAsset('/images/logo/bottom-right-corner-flower-ny.png');
 	const appShellStyle = `--app-flower-top-left: url("${topLeftFlower}"); --app-flower-bottom-right: url("${bottomRightFlower}");`;
+	let cookieConsent: CookieConsent;
 
 	$: auth.setUser(data.user ?? null);
 </script>
@@ -27,7 +29,8 @@
 	<main class="page-main">
 		<slot />
 	</main>
-	<Footer />
+	<Footer on:privacy={() => cookieConsent?.openPrivacy()} />
+	<CookieConsent bind:this={cookieConsent} />
 	<Toast />
 	<ConfirmDialog />
 </div>

--- a/Client/src/routes/+layout.svelte
+++ b/Client/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { base } from '$app/paths';
 	import '$lib/styles/global.css';
 	import Navbar from '$lib/components/layout/Navbar.svelte';
 	import Footer from '$lib/components/layout/Footer.svelte';
@@ -7,10 +6,13 @@
 	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte';
 	import { brand } from '$lib/config/site';
 	import { auth } from '$lib/stores/authStore';
+	import { staticAsset } from '$lib/utils/routes';
 
 	export let data;
 
-	const appShellStyle = `--app-flower-top-left: url("${base}/images/logo/top-left-corner-flower-ny.png"); --app-flower-bottom-right: url("${base}/images/logo/bottom-right-corner-flower-ny.png");`;
+	const topLeftFlower = staticAsset('/images/logo/top-left-corner-flower-ny.png');
+	const bottomRightFlower = staticAsset('/images/logo/bottom-right-corner-flower-ny.png');
+	const appShellStyle = `--app-flower-top-left: url("${topLeftFlower}"); --app-flower-bottom-right: url("${bottomRightFlower}");`;
 
 	$: auth.setUser(data.user ?? null);
 </script>

--- a/Client/src/routes/about/+page.svelte
+++ b/Client/src/routes/about/+page.svelte
@@ -20,7 +20,6 @@
 		</div>
 		<article class="about-page__content">
 			<p class="eyebrow">Om mig</p>
-			<h1>{data.about?.title || 'Med hjärtat som kompass'}</h1>
 			<div class="prose about-page__prose">
 				{@html data.about?.content ||
 					'<p>Här kommer Saras presentation att visas när den finns i API:t.</p>'}
@@ -59,15 +58,6 @@
 	.about-page__content {
 		justify-self: start;
 		width: min(100%, 620px);
-	}
-
-	h1 {
-		margin: 0.25rem 0 1.25rem;
-		max-width: 11ch;
-		color: var(--color-heading);
-		font-family: var(--font-serif);
-		font-size: clamp(2.75rem, 4.8vw, 4.5rem);
-		line-height: 0.95;
 	}
 
 	.about-page__prose {

--- a/Client/src/routes/contact/+page.svelte
+++ b/Client/src/routes/contact/+page.svelte
@@ -47,7 +47,7 @@
 		<div>
 			<p class="eyebrow">Kontakt</p>
 			<h1>Skriv några rader</h1>
-			<p>Här kan du skicka en hälsning, fråga eller tanke. Formuläret går direkt till API:t.</p>
+			<p>Här kan du skicka en hälsning, fråga eller tanke. Jag läser allt med värme.</p>
 		</div>
 
 		<form class="card" on:submit|preventDefault={submit}>


### PR DESCRIPTION
Summary

This PR improves the Svelte frontend GitHub Pages experience and refines a few user-facing content/details.

Changes
GitHub Pages asset fixes

- Fixed remaining flower corner image 404s on GitHub Pages
- Updated remaining hardcoded asset paths to use centralized base-aware helpers
- Improved compatibility with /sarasblogg-workspace base path deployments

About page cleanup

- Removed the large duplicated “Med hjärtat som kompass” heading from the About page

Contact page copy

- Replaced technical API-oriented contact text with more natural user-facing wording
- Cookie / privacy UX

- Added GDPR/cookie consent banner
- Consent persists after acceptance
- Added persistent footer link:
- Integritet · Cookies
- Footer link reopens the privacy/cookie modal even after consent has already been accepted

Verification

- npm run check
- npm run build

Notes

- No backend/API/auth changes
- No Razor frontend changes
- Frontend-only improvements for Svelte client and GitHub Pages deployment