### PR TITLE
fix(auth): support SvelteKit base path in Google external login callback

### DIFF
--- a/Client/src/lib/services/authService.ts
+++ b/Client/src/lib/services/authService.ts
@@ -34,7 +34,11 @@ export async function getCurrentUser(fetchFn: ApiFetch): Promise<AuthSessionDto 
 	try {
 		return await apiGet<AuthSessionDto>(fetchFn, '/api/users/me');
 	} catch (error) {
-		if (error instanceof Error && 'status' in error && (error as { status: number }).status === 401) {
+		if (
+			error instanceof Error &&
+			'status' in error &&
+			(error as { status: number }).status === 401
+		) {
 			return null;
 		}
 		throw error;
@@ -54,7 +58,10 @@ export async function login(
 	});
 }
 
-export async function register(fetchFn: ApiFetch, request: RegisterRequest): Promise<BasicResultDto> {
+export async function register(
+	fetchFn: ApiFetch,
+	request: RegisterRequest
+): Promise<BasicResultDto> {
 	return apiPost<BasicResultDto>(fetchFn, '/api/auth/register', request);
 }
 
@@ -62,14 +69,26 @@ export async function logout(fetchFn: ApiFetch): Promise<void> {
 	await apiPost<void>(fetchFn, '/api/auth/logout', undefined, { emptyResponse: true });
 }
 
-export async function exchangeExternalLoginCode(fetchFn: ApiFetch, code: string): Promise<LoginResponse> {
+export async function exchangeExternalLoginCode(
+	fetchFn: ApiFetch,
+	code: string
+): Promise<LoginResponse> {
 	return apiPost<LoginResponse>(fetchFn, '/api/auth/external/exchange', { code });
 }
 
-export function getGoogleLoginUrl(returnUrl: string, localReturnUrl = '/') {
+export function getGoogleLoginUrl(
+	returnUrl: string,
+	localReturnUrl = '/',
+	callbackPath = '/auth/external/callback/'
+) {
 	const url = new URL(`${getExternalApiBaseUrl()}/api/auth/external/google/start`);
+
 	url.searchParams.set('returnUrl', returnUrl);
-	url.searchParams.set('callbackPath', '/auth/external/callback/');
-	if (localReturnUrl) url.searchParams.set('localReturnUrl', localReturnUrl);
+	url.searchParams.set('callbackPath', callbackPath);
+
+	if (localReturnUrl) {
+		url.searchParams.set('localReturnUrl', localReturnUrl);
+	}
+
 	return url.toString();
 }

--- a/Client/src/routes/login/+page.svelte
+++ b/Client/src/routes/login/+page.svelte
@@ -6,10 +6,16 @@
 	import FormField from '$lib/components/forms/FormField.svelte';
 	import { useClientFetch } from '$lib/api/clientFetch';
 	import { getFriendlyApiMessage } from '$lib/api/apiErrors';
-	import { getCurrentUser, getGoogleLoginUrl, login, mapToFrontendUser } from '$lib/services/authService';
+	import {
+		getCurrentUser,
+		getGoogleLoginUrl,
+		login,
+		mapToFrontendUser
+	} from '$lib/services/authService';
 	import { auth } from '$lib/stores/authStore';
 	import { toasts } from '$lib/stores/toastStore';
 	import { routes } from '$lib/utils/routes';
+	import { base } from '$app/paths';
 
 	const getClientFetch = useClientFetch();
 
@@ -40,7 +46,11 @@
 	}
 
 	function loginWithGoogle() {
-		window.location.href = getGoogleLoginUrl(window.location.origin, returnUrl);
+		window.location.href = getGoogleLoginUrl(
+			window.location.origin,
+			returnUrl,
+			`${base}/auth/external/callback`
+		);
 	}
 </script>
 
@@ -48,14 +58,23 @@
 	<title>Logga in | SarasBlogg</title>
 </svelte:head>
 
-<AuthPanel title="Välkommen tillbaka" text="Logga in för att kommentera, hantera din profil och komma åt adminytor när du har behörighet.">
+<AuthPanel
+	title="Välkommen tillbaka"
+	text="Logga in för att kommentera, hantera din profil och komma åt adminytor när du har behörighet."
+>
 	<form class="form-grid" on:submit|preventDefault={handleLogin}>
 		<FormField label="E-post eller användarnamn" id="login-identity">
 			<input id="login-identity" bind:value={userNameOrEmail} autocomplete="username" required />
 		</FormField>
 
 		<FormField label="Lösenord" id="login-password">
-			<input id="login-password" type="password" bind:value={password} autocomplete="current-password" required />
+			<input
+				id="login-password"
+				type="password"
+				bind:value={password}
+				autocomplete="current-password"
+				required
+			/>
 		</FormField>
 
 		<label class="check"><input type="checkbox" bind:checked={rememberMe} /> Kom ihåg mig</label>


### PR DESCRIPTION
## PR: Fix Google external login callback handling for SvelteKit + GitHub Pages

### Summary

Fixes external Google login callback routing for the Svelte frontend when hosted under a SvelteKit base path (GitHub Pages), while preserving the existing Razor frontend flow.

### What changed

#### API

* External auth callback flow now supports a client-provided `callbackPath`
* API validates:

  * allowed frontend origin
  * safe local callback path
* Razor fallback callback remains the default when no `callbackPath` is provided
* Removed frontend-specific redirect assumptions from API config

#### Svelte frontend

* Google login now uses SvelteKit `base` path
* Callback path is generated dynamically:

  * local dev → `/auth/external/callback`
  * GitHub Pages → `/sarasblogg-workspace/auth/external/callback`
* Prevents GitHub Pages 404 after successful Google login

### Result

Both frontends now work simultaneously:

* Razor frontend login remains unchanged
* Svelte frontend works locally and on GitHub Pages
* API stays frontend-agnostic and contract-driven

### Verified

* API build passed
* Razor frontend build passed
* Svelte `npm run check` passed
* Svelte production build passed
* Google auth flow verified for:

  * Razor
  * local Svelte
  * GitHub Pages Svelte
