### PR TITLE
feat(svelte): improve profile, blog metadata and content parity

### DIFF
--- a/API/Controllers/Blogg/BloggController.cs
+++ b/API/Controllers/Blogg/BloggController.cs
@@ -6,9 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using SarasBloggAPI.Data;
 using SarasBloggAPI.DTOs.Blogg;
 using System.Globalization;
-using System.Net;
 using System.Text;
-using System.Text.RegularExpressions;
 using BloggModel = SarasBloggAPI.Models.Blogg;
 
 
@@ -219,13 +217,18 @@ namespace SarasBloggAPI.Controllers.Blogg
 
         private static BlogPostSummaryDto ToSummaryDto(BloggModel blogg)
         {
+            var isTitleGenerated = IsTitleGenerated(blogg);
+
             return new BlogPostSummaryDto
             {
                 Id = blogg.Id,
                 Slug = CreateSlug(blogg),
                 Title = blogg.Title ?? string.Empty,
+                ShowTitle = ShouldShowTitle(blogg, isTitleGenerated),
+                IsTitleGenerated = isTitleGenerated,
                 Author = blogg.Author,
                 Excerpt = CreateExcerpt(blogg.Content),
+                ReadingTimeMinutes = BlogTextHelper.CalculateReadingTimeMinutes(blogg.Content),
                 PublishedAtUtc = blogg.LaunchDate,
                 IsArchived = blogg.IsArchived,
                 ViewCount = blogg.ViewCount,
@@ -236,14 +239,18 @@ namespace SarasBloggAPI.Controllers.Blogg
         private static BlogPostDetailDto ToDetailDto(BloggModel blogg)
         {
             var images = GetOrderedImages(blogg).ToList();
+            var isTitleGenerated = IsTitleGenerated(blogg);
 
             return new BlogPostDetailDto
             {
                 Id = blogg.Id,
                 Slug = CreateSlug(blogg),
                 Title = blogg.Title ?? string.Empty,
+                ShowTitle = ShouldShowTitle(blogg, isTitleGenerated),
+                IsTitleGenerated = isTitleGenerated,
                 Content = blogg.Content,
                 Author = blogg.Author,
+                ReadingTimeMinutes = BlogTextHelper.CalculateReadingTimeMinutes(blogg.Content),
                 PublishedAtUtc = blogg.LaunchDate,
                 IsArchived = blogg.IsArchived,
                 ViewCount = blogg.ViewCount,
@@ -323,17 +330,21 @@ namespace SarasBloggAPI.Controllers.Blogg
 
         private static string CreateExcerpt(string? html, int maxLength = 180)
         {
-            if (string.IsNullOrWhiteSpace(html))
+            var text = BlogTextHelper.StripHtml(html);
+            if (string.IsNullOrWhiteSpace(text))
                 return string.Empty;
-
-            var text = Regex.Replace(html, "<.*?>", " ");
-            text = WebUtility.HtmlDecode(text);
-            text = Regex.Replace(text, "\\s+", " ").Trim();
 
             if (text.Length <= maxLength)
                 return text;
 
             return text[..maxLength].TrimEnd() + "...";
         }
+
+        private static bool IsTitleGenerated(BloggModel blogg)
+            => blogg.IsTitleGenerated ??
+               BlogTextHelper.IsTitleGeneratedFromContent(blogg.Title, blogg.Content);
+
+        private static bool ShouldShowTitle(BloggModel blogg, bool isTitleGenerated)
+            => blogg.ShowTitle && !isTitleGenerated && !string.IsNullOrWhiteSpace(blogg.Title);
     }
 }

--- a/API/Controllers/Comment/ForbiddenWordController.cs
+++ b/API/Controllers/Comment/ForbiddenWordController.cs
@@ -29,6 +29,9 @@ namespace SarasBloggAPI.Controllers.Comment
         [HttpPost]
         public async Task<ActionResult<ForbiddenWord>> Create([FromBody] ForbiddenWord word)
         {
+            if (word == null || string.IsNullOrWhiteSpace(word.WordPattern))
+                return BadRequest("Ord eller mönster saknas.");
+
             var created = await _manager.CreateAsync(word);
             return CreatedAtAction(nameof(GetAll), new { id = created.Id }, created);
         }

--- a/API/DAL/ForbiddenWordManager.cs
+++ b/API/DAL/ForbiddenWordManager.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using SarasBloggAPI.Data;
 using SarasBloggAPI.Models;
+using SarasBloggAPI.Services.Comment;
 
 namespace SarasBloggAPI.DAL
 {
@@ -25,6 +26,7 @@ namespace SarasBloggAPI.DAL
 
         public async Task<ForbiddenWord> CreateAsync(ForbiddenWord word)
         {
+            word.WordPattern = ForbiddenWordPatternNormalizer.Normalize(word.WordPattern);
             _context.ForbiddenWords.Add(word);
             await _context.SaveChangesAsync();
             return word;
@@ -35,7 +37,7 @@ namespace SarasBloggAPI.DAL
             var existing = await _context.ForbiddenWords.FindAsync(word.Id);
             if (existing == null) return false;
 
-            existing.WordPattern = word.WordPattern;
+            existing.WordPattern = ForbiddenWordPatternNormalizer.Normalize(word.WordPattern);
             await _context.SaveChangesAsync();
             return true;
         }

--- a/API/DTOs/Blogg/BlogPostDetailDto.cs
+++ b/API/DTOs/Blogg/BlogPostDetailDto.cs
@@ -5,8 +5,11 @@ namespace SarasBloggAPI.DTOs.Blogg
         public int Id { get; set; }
         public string Slug { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
+        public bool ShowTitle { get; set; }
+        public bool IsTitleGenerated { get; set; }
         public string Content { get; set; } = string.Empty;
         public string Author { get; set; } = string.Empty;
+        public int ReadingTimeMinutes { get; set; }
         public DateTime PublishedAtUtc { get; set; }
         public bool IsArchived { get; set; }
         public int ViewCount { get; set; }

--- a/API/DTOs/Blogg/BlogPostSummaryDto.cs
+++ b/API/DTOs/Blogg/BlogPostSummaryDto.cs
@@ -5,8 +5,11 @@ namespace SarasBloggAPI.DTOs.Blogg
         public int Id { get; set; }
         public string Slug { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
+        public bool ShowTitle { get; set; }
+        public bool IsTitleGenerated { get; set; }
         public string Author { get; set; } = string.Empty;
         public string Excerpt { get; set; } = string.Empty;
+        public int ReadingTimeMinutes { get; set; }
         public DateTime PublishedAtUtc { get; set; }
         public bool IsArchived { get; set; }
         public int ViewCount { get; set; }

--- a/API/DTOs/Blogg/BlogPostWriteRequest.cs
+++ b/API/DTOs/Blogg/BlogPostWriteRequest.cs
@@ -7,6 +7,7 @@ namespace SarasBloggAPI.DTOs.Blogg
     public class BlogPostWriteRequest
     {
         public string? Title { get; set; }
+        public bool? ShowTitle { get; set; }
 
         [Required]
         public string? Content { get; set; }

--- a/API/Data/Migrations/20260510120000_AddBlogTitleMetadata.cs
+++ b/API/Data/Migrations/20260510120000_AddBlogTitleMetadata.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using SarasBloggAPI.Data;
+
+#nullable disable
+
+namespace SarasBloggAPI.Data.Migrations
+{
+    [DbContext(typeof(MyDbContext))]
+    [Migration("20260510120000_AddBlogTitleMetadata")]
+    public partial class AddBlogTitleMetadata : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsTitleGenerated",
+                table: "Blogg",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowTitle",
+                table: "Blogg",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsTitleGenerated",
+                table: "Blogg");
+
+            migrationBuilder.DropColumn(
+                name: "ShowTitle",
+                table: "Blogg");
+        }
+    }
+}

--- a/API/Migrations/MyDbContextModelSnapshot.cs
+++ b/API/Migrations/MyDbContextModelSnapshot.cs
@@ -280,8 +280,14 @@ namespace SarasBloggAPI.Migrations
                     b.Property<bool>("IsArchived")
                         .HasColumnType("boolean");
 
+                    b.Property<bool?>("IsTitleGenerated")
+                        .HasColumnType("boolean");
+
                     b.Property<DateTime>("LaunchDate")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("ShowTitle")
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Title")
                         .HasColumnType("text");

--- a/API/Models/Blogg.cs
+++ b/API/Models/Blogg.cs
@@ -10,6 +10,8 @@ namespace SarasBloggAPI.Models
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
         public string? Title { get; set; } = "";
+        public bool ShowTitle { get; set; } = false;
+        public bool? IsTitleGenerated { get; set; }
         public string Content { get; set; } = "";
         public string Author { get; set; } = "";
         public ICollection<BloggImage>? Images { get; set; }

--- a/API/Services/Blogg/BlogPostService.cs
+++ b/API/Services/Blogg/BlogPostService.cs
@@ -1,6 +1,4 @@
-using System.Net;
 using System.Security.Claims;
-using System.Text.RegularExpressions;
 using Ganss.Xss;
 using SarasBloggAPI.DAL;
 using SarasBloggAPI.DTOs.Blogg;
@@ -27,9 +25,12 @@ namespace SarasBloggAPI.Services.Blogg
         public async Task<BloggModel> CreateAsync(BlogPostWriteRequest request, ClaimsPrincipal user)
         {
             var sanitizedContent = SanitizeContent(request.Content);
+            var title = ResolveTitle(request.Title, sanitizedContent, request.ShowTitle);
             var blogg = new BloggModel
             {
-                Title = ResolveTitle(request.Title, sanitizedContent),
+                Title = title.Value,
+                ShowTitle = title.ShowTitle,
+                IsTitleGenerated = title.IsGenerated,
                 Content = sanitizedContent,
                 Author = ResolveAuthor(request.Author, user),
                 LaunchDate = ResolveLaunchDateUtc(request),
@@ -55,8 +56,11 @@ namespace SarasBloggAPI.Services.Blogg
                 return null;
 
             var sanitizedContent = SanitizeContent(request.Content);
+            var title = ResolveTitle(request.Title, sanitizedContent, request.ShowTitle, existing.ShowTitle);
 
-            existing.Title = ResolveTitle(request.Title, sanitizedContent);
+            existing.Title = title.Value;
+            existing.ShowTitle = title.ShowTitle;
+            existing.IsTitleGenerated = title.IsGenerated;
             existing.Content = sanitizedContent;
             existing.Author = ResolveAuthor(request.Author, user);
             existing.LaunchDate = ResolveLaunchDateUtc(request);
@@ -91,44 +95,24 @@ namespace SarasBloggAPI.Services.Blogg
             return DateTime.UtcNow;
         }
 
-        private static string ResolveTitle(string? title, string content)
+        private static ResolvedTitle ResolveTitle(
+            string? title,
+            string content,
+            bool? requestedShowTitle,
+            bool existingShowTitle = false)
         {
             if (!string.IsNullOrWhiteSpace(title))
-                return title.Trim();
-
-            return GenerateFallbackTitle(content);
-        }
-
-        private static string GenerateFallbackTitle(string? content, int maxLength = 80)
-        {
-            var plain = StripHtml(content);
-            if (string.IsNullOrWhiteSpace(plain))
-                return string.Empty;
-
-            var text = plain.Trim();
-
-            if (text.Length <= maxLength)
-                return text;
-
-            var truncated = text.Substring(0, maxLength);
-
-            var lastSpace = truncated.LastIndexOf(' ');
-            if (lastSpace > 20)
             {
-                truncated = truncated.Substring(0, lastSpace);
+                var showTitle = requestedShowTitle ?? existingShowTitle;
+                return new ResolvedTitle(title.Trim(), IsGenerated: false, ShowTitle: showTitle);
             }
 
-            return truncated.TrimEnd() + "...";
+            return new ResolvedTitle(
+                BlogTextHelper.GenerateFallbackTitle(content),
+                IsGenerated: true,
+                ShowTitle: false);
         }
 
-        private static string StripHtml(string? html)
-        {
-            if (string.IsNullOrWhiteSpace(html))
-                return string.Empty;
-
-            var text = Regex.Replace(html, "<[^>]+>", " ");
-            text = WebUtility.HtmlDecode(text);
-            return Regex.Replace(text, "\\s+", " ").Trim();
-        }
+        private readonly record struct ResolvedTitle(string Value, bool IsGenerated, bool ShowTitle);
     }
 }

--- a/API/Services/Blogg/BlogTextHelper.cs
+++ b/API/Services/Blogg/BlogTextHelper.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace SarasBloggAPI.Services.Blogg;
+
+public static class BlogTextHelper
+{
+    public static string StripHtml(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return string.Empty;
+
+        var text = Regex.Replace(html, "<[^>]+>", " ");
+        text = WebUtility.HtmlDecode(text);
+        return Regex.Replace(text, "\\s+", " ").Trim();
+    }
+
+    public static string GenerateFallbackTitle(string? content, int maxLength = 80)
+    {
+        var plain = StripHtml(content);
+        if (string.IsNullOrWhiteSpace(plain))
+            return string.Empty;
+
+        var text = plain.Trim();
+        if (text.Length <= maxLength)
+            return text;
+
+        var truncated = text.Substring(0, maxLength);
+        var lastSpace = truncated.LastIndexOf(' ');
+        if (lastSpace > 20)
+        {
+            truncated = truncated.Substring(0, lastSpace);
+        }
+
+        return truncated.TrimEnd() + "...";
+    }
+
+    public static int CalculateReadingTimeMinutes(string? content, int wordsPerMinute = 220)
+    {
+        var text = StripHtml(content);
+        if (string.IsNullOrWhiteSpace(text))
+            return 1;
+
+        var words = Regex.Matches(text, "\\S+").Count;
+        return Math.Max(1, (int)Math.Ceiling(words / (double)wordsPerMinute));
+    }
+
+    public static bool IsTitleGeneratedFromContent(string? title, string? htmlContent)
+    {
+        if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(htmlContent))
+            return false;
+
+        var titleNorm = Normalize(StripHtml(RemoveTrailingEllipsis(title)));
+        if (titleNorm.Length < 5)
+            return false;
+
+        var contentNorm = Normalize(StripHtml(htmlContent));
+
+        return contentNorm.StartsWith(titleNorm, StringComparison.Ordinal) ||
+               (contentNorm.Length >= titleNorm.Length &&
+                contentNorm[..titleNorm.Length].Equals(titleNorm, StringComparison.Ordinal));
+    }
+
+    private static string RemoveTrailingEllipsis(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.EndsWith("...", StringComparison.Ordinal))
+            return trimmed[..^3];
+
+        if (trimmed.EndsWith('\u2026'))
+            return trimmed[..^1];
+
+        return trimmed;
+    }
+
+    private static string Normalize(string text)
+        => Regex.Replace(text.ToLowerInvariant(), "\\s+", " ").Trim();
+}

--- a/API/Services/Comment/ForbiddenWordPatternNormalizer.cs
+++ b/API/Services/Comment/ForbiddenWordPatternNormalizer.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+
+namespace SarasBloggAPI.Services.Comment;
+
+public static class ForbiddenWordPatternNormalizer
+{
+    private static readonly IReadOnlyDictionary<char, string> CharacterMap = new Dictionary<char, string>
+    {
+        ['a'] = "[a4@]",
+        ['o'] = "[o0]",
+        ['e'] = "[e3]",
+        ['i'] = "[i1|!]",
+        ['u'] = "[u\u00FCv]",
+        ['c'] = "[ck]",
+        ['s'] = "[s$5]",
+        ['g'] = "[g9]"
+    };
+
+    private static readonly Regex RegexTokenPattern = new(
+        @"[\\\[\]\(\)\{\}\|\^\$\*\+\?]",
+        RegexOptions.Compiled);
+
+    public static string Normalize(string? wordOrPattern)
+    {
+        if (string.IsNullOrWhiteSpace(wordOrPattern))
+            return string.Empty;
+
+        var trimmed = wordOrPattern.Trim();
+        if (LooksLikeRegexPattern(trimmed) && IsValidRegex(trimmed))
+            return trimmed;
+
+        return ToRegexPattern(trimmed);
+    }
+
+    private static bool LooksLikeRegexPattern(string value)
+        => RegexTokenPattern.IsMatch(value);
+
+    private static bool IsValidRegex(string pattern)
+    {
+        try
+        {
+            _ = new Regex(pattern);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string ToRegexPattern(string word)
+    {
+        return string.Concat(word.ToLowerInvariant().Select(c =>
+            CharacterMap.TryGetValue(c, out var replacement)
+                ? replacement
+                : Regex.Escape(c.ToString())));
+    }
+}

--- a/APITests/Integration/BlogPostWriteTests.cs
+++ b/APITests/Integration/BlogPostWriteTests.cs
@@ -28,6 +28,7 @@ public class BlogPostWriteTests : IClassFixture<CustomWebApplicationFactory<Prog
         var response = await client.PostAsJsonAsync("/api/blogg", new BlogPostWriteRequest
         {
             Title = "API owned post",
+            ShowTitle = true,
             Content = "<p>Hello <strong>world</strong></p>",
             Author = "Sara",
             LaunchDateLocal = new DateTime(2026, 1, 15, 9, 30, 0),
@@ -40,6 +41,8 @@ public class BlogPostWriteTests : IClassFixture<CustomWebApplicationFactory<Prog
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(created);
         Assert.Equal("API owned post", created!.Title);
+        Assert.True(created.ShowTitle);
+        Assert.False(created.IsTitleGenerated);
         Assert.Equal("<p>Hello <strong>world</strong></p>", created.Content);
         Assert.Equal("Sara", created.Author);
         Assert.Equal("creator-user", created.UserId);
@@ -70,6 +73,8 @@ public class BlogPostWriteTests : IClassFixture<CustomWebApplicationFactory<Prog
         var stored = await FindBloggAsync(bloggId);
         Assert.NotNull(stored);
         Assert.Equal("Updated title", stored!.Title);
+        Assert.True(stored.ShowTitle);
+        Assert.False(stored.IsTitleGenerated);
         Assert.Equal("<p>Updated content</p>", stored.Content);
         Assert.Equal("Updated author", stored.Author);
         Assert.True(stored.Hidden);
@@ -97,6 +102,8 @@ public class BlogPostWriteTests : IClassFixture<CustomWebApplicationFactory<Prog
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(created);
         Assert.Equal("Det här blir titel från innehållet", created!.Title);
+        Assert.False(created.ShowTitle);
+        Assert.True(created.IsTitleGenerated);
     }
 
     [Fact]
@@ -175,6 +182,8 @@ public class BlogPostWriteTests : IClassFixture<CustomWebApplicationFactory<Prog
         var blogg = new Blogg
         {
             Title = "Original title",
+            ShowTitle = true,
+            IsTitleGenerated = false,
             Content = "<p>Original content</p>",
             Author = "Original author",
             LaunchDate = DateTime.UtcNow.AddDays(-1),

--- a/APITests/Integration/ForbiddenWordTests.cs
+++ b/APITests/Integration/ForbiddenWordTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Http.Json;
+using APITests.Infrastructure;
+using APITests.TestHelpers;
+using Microsoft.Extensions.DependencyInjection;
+using SarasBloggAPI;
+using SarasBloggAPI.Data;
+using SarasBloggAPI.Models;
+
+namespace APITests.Integration;
+
+public class ForbiddenWordTests : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+
+    public ForbiddenWordTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Post_ForbiddenWord_NormalizesPlainWords()
+    {
+        await ResetForbiddenWordsAsync();
+        var client = CreateModeratorClient();
+
+        var response = await client.PostAsJsonAsync("/api/forbiddenword", new ForbiddenWord
+        {
+            WordPattern = "saga"
+        });
+
+        var created = await response.Content.ReadFromJsonAsync<ForbiddenWord>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(created);
+        Assert.Equal("[s$5][a4@][g9][a4@]", created!.WordPattern);
+    }
+
+    [Fact]
+    public async Task Post_ForbiddenWord_PreservesAlreadyNormalizedPatterns()
+    {
+        await ResetForbiddenWordsAsync();
+        var client = CreateModeratorClient();
+
+        var normalized = "[s$5][a4@][g9][a4@]";
+        var response = await client.PostAsJsonAsync("/api/forbiddenword", new ForbiddenWord
+        {
+            WordPattern = normalized
+        });
+
+        var created = await response.Content.ReadFromJsonAsync<ForbiddenWord>();
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(created);
+        Assert.Equal(normalized, created!.WordPattern);
+    }
+
+    private HttpClient CreateModeratorClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "moderator-user");
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserNameHeader, "Moderator");
+        client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, "admin");
+        return client;
+    }
+
+    private async Task ResetForbiddenWordsAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+
+        db.ForbiddenWords.RemoveRange(db.ForbiddenWords);
+        await db.SaveChangesAsync();
+    }
+}

--- a/APITests/Integration/PublicBloggTests.cs
+++ b/APITests/Integration/PublicBloggTests.cs
@@ -107,6 +107,42 @@ public class PublicBloggTests : IClassFixture<CustomWebApplicationFactory<Progra
     }
 
     [Fact]
+    public async Task Get_PublicBloggs_UsesFullContentReadingTimeAndTitleMetadata()
+    {
+        await ResetBlogDataAsync();
+
+        var content = "<p>" + string.Join(" ", Enumerable.Range(1, 260).Select(i => $"ord{i}")) + "</p>";
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+            db.Bloggs.Add(new Blogg
+            {
+                Title = "Long public",
+                ShowTitle = true,
+                IsTitleGenerated = false,
+                Content = content,
+                Author = "IntegrationTest",
+                LaunchDate = DateTime.UtcNow.AddHours(-1),
+                IsArchived = false,
+                Hidden = false
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var list = await _client.GetFromJsonAsync<BlogPostListDto>("/api/blogg/public?page=1&pageSize=10", JsonOptions);
+        var item = Assert.Single(list!.Items);
+        var detail = await _client.GetFromJsonAsync<BlogPostDetailDto>($"/api/blogg/public/{item.Slug}", JsonOptions);
+
+        Assert.Equal(2, item.ReadingTimeMinutes);
+        Assert.True(item.ShowTitle);
+        Assert.False(item.IsTitleGenerated);
+        Assert.NotNull(detail);
+        Assert.Equal(item.ReadingTimeMinutes, detail!.ReadingTimeMinutes);
+        Assert.True(detail.ShowTitle);
+        Assert.False(detail.IsTitleGenerated);
+    }
+
+    [Fact]
     public async Task Get_PublicBloggByIdOrSlug_Returns404ForHiddenOrFuturePosts()
     {
         await ResetBlogDataAsync();

--- a/Client/src/lib/api/apiClient.ts
+++ b/Client/src/lib/api/apiClient.ts
@@ -87,22 +87,69 @@ export async function apiRequest<T>(
 	return payload as T;
 }
 
+export async function apiDownload(
+	fetchFn: ApiFetch,
+	path: string,
+	options: ApiRequestOptions = {}
+): Promise<Response> {
+	const init = { ...options } as RequestInit & { emptyResponse?: boolean };
+	delete init.body;
+	delete init.emptyResponse;
+
+	const headers = new Headers(options.headers);
+	if (!headers.has('Accept')) headers.set('Accept', '*/*');
+
+	const response = await fetchFn(resolveApiUrl(path), {
+		...init,
+		credentials: init.credentials ?? 'include',
+		headers,
+		method: init.method ?? 'GET'
+	});
+
+	if (!response.ok) {
+		const payload = await readResponsePayload(response);
+		throw createApiError(response, payload);
+	}
+
+	return response;
+}
+
 export function apiGet<T>(fetchFn: ApiFetch, path: string, options: ApiRequestOptions = {}) {
 	return apiRequest<T>(fetchFn, path, { ...options, method: 'GET' });
 }
 
-export function apiPost<T>(fetchFn: ApiFetch, path: string, body?: ApiRequestOptions['body'], options: ApiRequestOptions = {}) {
+export function apiPost<T>(
+	fetchFn: ApiFetch,
+	path: string,
+	body?: ApiRequestOptions['body'],
+	options: ApiRequestOptions = {}
+) {
 	return apiRequest<T>(fetchFn, path, { ...options, method: 'POST', body });
 }
 
-export function apiPut<T>(fetchFn: ApiFetch, path: string, body?: ApiRequestOptions['body'], options: ApiRequestOptions = {}) {
+export function apiPut<T>(
+	fetchFn: ApiFetch,
+	path: string,
+	body?: ApiRequestOptions['body'],
+	options: ApiRequestOptions = {}
+) {
 	return apiRequest<T>(fetchFn, path, { ...options, method: 'PUT', body });
 }
 
-export function apiPatch<T>(fetchFn: ApiFetch, path: string, body?: ApiRequestOptions['body'], options: ApiRequestOptions = {}) {
+export function apiPatch<T>(
+	fetchFn: ApiFetch,
+	path: string,
+	body?: ApiRequestOptions['body'],
+	options: ApiRequestOptions = {}
+) {
 	return apiRequest<T>(fetchFn, path, { ...options, method: 'PATCH', body });
 }
 
-export function apiDelete<T>(fetchFn: ApiFetch, path: string, body?: ApiRequestOptions['body'], options: ApiRequestOptions = {}) {
+export function apiDelete<T>(
+	fetchFn: ApiFetch,
+	path: string,
+	body?: ApiRequestOptions['body'],
+	options: ApiRequestOptions = {}
+) {
 	return apiRequest<T>(fetchFn, path, { ...options, method: 'DELETE', body });
 }

--- a/Client/src/lib/components/admin/PostEditor.svelte
+++ b/Client/src/lib/components/admin/PostEditor.svelte
@@ -11,13 +11,17 @@
 	export let isUploading = false;
 	export let canManageImages = false;
 	export let submitLabel = 'Spara';
-	export let onSave: (request: BlogPostWriteRequest, files: File[]) => void | Promise<void> = () => {};
+	export let onSave: (
+		request: BlogPostWriteRequest,
+		files: File[]
+	) => void | Promise<void> = () => {};
 	export let onCancel: () => void = () => {};
 	export let onDeleteImage: (image: BloggImageDto) => void | Promise<void> = () => {};
 	export let onMakeCover: (image: BloggImageDto) => void | Promise<void> = () => {};
 	export let uploadEditorImage: ((file: File) => Promise<string>) | undefined;
 
 	let title = '';
+	let showTitle = false;
 	let author = '';
 	let content = '';
 	let launchDateLocal = '';
@@ -29,6 +33,7 @@
 
 	$: if (post) {
 		title = post.title ?? '';
+		showTitle = post.showTitle ?? false;
 		author = post.author ?? '';
 		content = post.content ?? '';
 		launchDateLocal = toLocalDateTimeInput(post.launchDate);
@@ -36,6 +41,7 @@
 		isArchived = post.isArchived;
 	} else {
 		title = '';
+		showTitle = false;
 		author = '';
 		content = '';
 		launchDateLocal = '';
@@ -51,6 +57,7 @@
 	function getRequest(): BlogPostWriteRequest {
 		return {
 			title: title.trim() || null,
+			showTitle: title.trim() ? showTitle : false,
 			author: author.trim() || null,
 			content,
 			launchDateLocal: launchDateLocal || null,
@@ -88,7 +95,13 @@
 		<input id="post-launch" type="datetime-local" bind:value={launchDateLocal} />
 	</FormField>
 
-	<RichTextEditor bind:value={content} id="post-content" label="Innehåll" height={550} uploadImage={uploadEditorImage} />
+	<RichTextEditor
+		bind:value={content}
+		id="post-content"
+		label="Innehåll"
+		height={550}
+		uploadImage={uploadEditorImage}
+	/>
 
 	{#if canManageImages}
 		<section class="image-manager" aria-labelledby="post-images-title">
@@ -110,7 +123,7 @@
 				<div class="pending-files">
 					<strong>Valda filer</strong>
 					<ul>
-						{#each selectedFiles as file}
+						{#each selectedFiles as file (file.name)}
 							<li>{file.name}</li>
 						{/each}
 					</ul>
@@ -124,8 +137,17 @@
 							<img src={resolveMediaUrl(image.filePath)} alt={`Bild ${index + 1} för inlägget`} />
 							<div>
 								<span>{index === 0 ? 'Första bild' : `Bild ${index + 1}`}</span>
-								<button type="button" disabled={index === 0 || isUploading} on:click={() => onMakeCover(image)}>Gör först</button>
-								<button type="button" class="danger" disabled={isUploading} on:click={() => onDeleteImage(image)}>Ta bort</button>
+								<button
+									type="button"
+									disabled={index === 0 || isUploading}
+									on:click={() => onMakeCover(image)}>Gör först</button
+								>
+								<button
+									type="button"
+									class="danger"
+									disabled={isUploading}
+									on:click={() => onDeleteImage(image)}>Ta bort</button
+								>
 							</div>
 						</article>
 					{/each}
@@ -139,13 +161,20 @@
 	{/if}
 
 	<div class="checks">
+		<label
+			><input type="checkbox" bind:checked={showTitle} disabled={!title.trim()} /> Visa titel i inlägget</label
+		>
 		<label><input type="checkbox" bind:checked={hidden} /> Dolt</label>
 		<label><input type="checkbox" bind:checked={isArchived} /> Arkiverat</label>
 	</div>
 
 	<div class="form-actions">
-		<Button type="button" variant="ghost" disabled={isSaving || isUploading} on:click={onCancel}>Avbryt</Button>
-		<Button type="submit" disabled={isSaving || isUploading}>{isSaving || isUploading ? 'Sparar...' : submitLabel}</Button>
+		<Button type="button" variant="ghost" disabled={isSaving || isUploading} on:click={onCancel}
+			>Avbryt</Button
+		>
+		<Button type="submit" disabled={isSaving || isUploading}
+			>{isSaving || isUploading ? 'Sparar...' : submitLabel}</Button
+		>
 	</div>
 </form>
 

--- a/Client/src/lib/components/blog/BlogCard.svelte
+++ b/Client/src/lib/components/blog/BlogCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { BlogPostSummaryDto } from '$lib/types/blog';
-	import { formatDate, readingMinutes } from '$lib/utils/dates';
+	import { formatDate } from '$lib/utils/dates';
 	import { blogPostPath, fallbackBlogImage, resolveMediaUrl } from '$lib/utils/routes';
 
 	export let post: BlogPostSummaryDto;
@@ -10,10 +10,13 @@
 	$: image = post.coverImage?.filePath
 		? resolveMediaUrl(post.coverImage.filePath)
 		: fallbackBlogImage(index);
-	$: title = post.title || 'Utan titel';
+	$: showTitle = post.showTitle && post.title.trim().length > 0;
+	$: title = post.title || 'inlägg';
+	$: readingTime = post.readingTimeMinutes || 1;
 </script>
 
 <article class="blog-card" class:blog-card--editorial={variant === 'editorial'}>
+	<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 	<a href={blogPostPath(post)} aria-label={`Läs ${title}`}>
 		<div class="blog-card__media">
 			<img class="blog-card__image" src={image} alt="" loading="lazy" />
@@ -22,11 +25,13 @@
 			{#if post.author}
 				<p class="blog-card__category">{post.author}</p>
 			{/if}
-			<h2>{title}</h2>
+			{#if showTitle}
+				<h2>{post.title}</h2>
+			{/if}
 			<p>{post.excerpt}</p>
 			<footer>
 				<span>{formatDate(post.publishedAtUtc)}</span>
-				<span>{readingMinutes(post.excerpt)} min läsning</span>
+				<span>{readingTime} min läsning</span>
 				<i aria-hidden="true">→</i>
 			</footer>
 		</div>

--- a/Client/src/lib/components/blog/BlogPost.svelte
+++ b/Client/src/lib/components/blog/BlogPost.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { BlogPostDetailDto } from '$lib/types/blog';
-	import { formatDate, readingMinutes } from '$lib/utils/dates';
+	import { formatDate } from '$lib/utils/dates';
 	import { fallbackBlogImage, resolveMediaUrl } from '$lib/utils/routes';
 
 	export let post: BlogPostDetailDto;
@@ -8,12 +8,16 @@
 	let activeIndex = 0;
 	let lightboxOpen = false;
 
-	$: gallery = (post.images?.length ? post.images : post.coverImage ? [post.coverImage] : []).map((image, index) => ({
-		id: image.id,
-		src: resolveMediaUrl(image.filePath),
-		alt: `${post.title || 'Bloggbild'} ${index + 1}`
-	}));
+	$: gallery = (post.images?.length ? post.images : post.coverImage ? [post.coverImage] : []).map(
+		(image, index) => ({
+			id: image.id,
+			src: resolveMediaUrl(image.filePath),
+			alt: `${post.title || 'Bloggbild'} ${index + 1}`
+		})
+	);
 	$: images = gallery.length > 0 ? gallery : [{ id: 0, src: fallbackBlogImage(post.id), alt: '' }];
+	$: showTitle = post.showTitle && post.title.trim().length > 0;
+	$: readingTime = post.readingTimeMinutes || 1;
 	$: if (activeIndex >= images.length) activeIndex = 0;
 
 	function previousImage() {
@@ -40,23 +44,40 @@
 <article class="post">
 	<header>
 		<p class="eyebrow">{post.author || 'SarasBlogg'}</p>
-		<h1>{post.title || 'Utan titel'}</h1>
+		{#if showTitle}
+			<h1>{post.title}</h1>
+		{/if}
 		<div class="post__meta">
 			<span>{formatDate(post.publishedAtUtc)}</span>
-			<span>{readingMinutes(post.content)} min läsning</span>
+			<span>{readingTime} min läsning</span>
 			<span>{post.viewCount} visningar</span>
 		</div>
 	</header>
 
 	<section class="gallery" aria-label="Inläggsbilder">
 		<div class="gallery__frame">
-			<button type="button" class="gallery__open" aria-label="Visa bilden större" on:click={() => (lightboxOpen = true)}>
+			<button
+				type="button"
+				class="gallery__open"
+				aria-label="Visa bilden större"
+				on:click={() => (lightboxOpen = true)}
+			>
 				<img class="post__cover-blur" src={images[activeIndex].src} alt="" aria-hidden="true" />
 				<img class="post__cover" src={images[activeIndex].src} alt={images[activeIndex].alt} />
 			</button>
 			{#if images.length > 1}
-				<button type="button" class="gallery__nav gallery__nav--prev" aria-label="Föregående bild" on:click|stopPropagation={previousImage}>‹</button>
-				<button type="button" class="gallery__nav gallery__nav--next" aria-label="Nästa bild" on:click|stopPropagation={nextImage}>›</button>
+				<button
+					type="button"
+					class="gallery__nav gallery__nav--prev"
+					aria-label="Föregående bild"
+					on:click|stopPropagation={previousImage}>‹</button
+				>
+				<button
+					type="button"
+					class="gallery__nav gallery__nav--next"
+					aria-label="Nästa bild"
+					on:click|stopPropagation={nextImage}>›</button
+				>
 			{/if}
 		</div>
 		{#if images.length > 1}
@@ -77,13 +98,25 @@
 	</section>
 
 	<div class="post__content prose">
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html post.content}
 	</div>
 </article>
 
 {#if lightboxOpen}
-	<div class="lightbox" role="dialog" aria-modal="true" aria-label="Förstorad bloggbild" tabindex="-1">
-		<button type="button" class="lightbox__backdrop" aria-label="Stäng bild" on:click={closeLightbox}></button>
+	<div
+		class="lightbox"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Förstorad bloggbild"
+		tabindex="-1"
+	>
+		<button
+			type="button"
+			class="lightbox__backdrop"
+			aria-label="Stäng bild"
+			on:click={closeLightbox}
+		></button>
 		<div class="lightbox__content">
 			<button type="button" aria-label="Stäng bild" on:click={closeLightbox}>×</button>
 			<img src={images[activeIndex].src} alt={images[activeIndex].alt} />

--- a/Client/src/lib/services/userService.ts
+++ b/Client/src/lib/services/userService.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, apiPost, apiPut, type ApiFetch } from '$lib/api/apiClient';
+import { apiDelete, apiDownload, apiGet, apiPost, apiPut, type ApiFetch } from '$lib/api/apiClient';
 import type { BasicResultDto, ChangeUserNameRequest, UpdateProfileRequest } from '$lib/types/auth';
 import type { PersonalDataDto, PublicUserDto, UserDto } from '$lib/types/user';
 
@@ -15,15 +15,25 @@ export function getUserRoles(fetchFn: ApiFetch, id: string) {
 }
 
 export function addUserRole(fetchFn: ApiFetch, id: string, roleName: string) {
-	return apiPost<void>(fetchFn, `/api/user/${id}/add-role/${encodeURIComponent(roleName)}`, undefined, {
-		emptyResponse: true
-	});
+	return apiPost<void>(
+		fetchFn,
+		`/api/user/${id}/add-role/${encodeURIComponent(roleName)}`,
+		undefined,
+		{
+			emptyResponse: true
+		}
+	);
 }
 
 export function removeUserRole(fetchFn: ApiFetch, id: string, roleName: string) {
-	return apiDelete<void>(fetchFn, `/api/user/${id}/remove-role/${encodeURIComponent(roleName)}`, undefined, {
-		emptyResponse: true
-	});
+	return apiDelete<void>(
+		fetchFn,
+		`/api/user/${id}/remove-role/${encodeURIComponent(roleName)}`,
+		undefined,
+		{
+			emptyResponse: true
+		}
+	);
 }
 
 export function changeMyUsername(fetchFn: ApiFetch, request: ChangeUserNameRequest) {
@@ -46,6 +56,28 @@ export function getMyPersonalData(fetchFn: ApiFetch) {
 	return apiGet<PersonalDataDto>(fetchFn, '/api/users/me/personal-data');
 }
 
+export async function downloadMyPersonalData(fetchFn: ApiFetch) {
+	const response = await apiDownload(fetchFn, '/api/users/me/personal-data/download');
+	return {
+		blob: await response.blob(),
+		filename: getDownloadFilename(response.headers.get('content-disposition'))
+	};
+}
+
+export function deleteMyAccount(fetchFn: ApiFetch, password?: string | null) {
+	return apiDelete<BasicResultDto>(fetchFn, '/api/users/me', { password: password || null });
+}
+
 export function deleteUser(fetchFn: ApiFetch, id: string) {
 	return apiDelete<void>(fetchFn, `/api/user/delete/${id}`, undefined, { emptyResponse: true });
+}
+
+function getDownloadFilename(contentDisposition: string | null) {
+	if (!contentDisposition) return 'PersonalData.json';
+
+	const utf8Match = /filename\*=UTF-8''([^;]+)/i.exec(contentDisposition);
+	if (utf8Match?.[1]) return decodeURIComponent(utf8Match[1]);
+
+	const filenameMatch = /filename="?([^";]+)"?/i.exec(contentDisposition);
+	return filenameMatch?.[1] ?? 'PersonalData.json';
 }

--- a/Client/src/lib/types/blog.ts
+++ b/Client/src/lib/types/blog.ts
@@ -9,8 +9,11 @@ export type BlogPostSummaryDto = {
 	id: number;
 	slug: string;
 	title: string;
+	showTitle: boolean;
+	isTitleGenerated: boolean;
 	author: string;
 	excerpt: string;
+	readingTimeMinutes: number;
 	publishedAtUtc: string;
 	isArchived: boolean;
 	viewCount: number;
@@ -21,8 +24,11 @@ export type BlogPostDetailDto = {
 	id: number;
 	slug: string;
 	title: string;
+	showTitle: boolean;
+	isTitleGenerated: boolean;
 	content: string;
 	author: string;
+	readingTimeMinutes: number;
 	publishedAtUtc: string;
 	isArchived: boolean;
 	viewCount: number;
@@ -40,6 +46,7 @@ export type BlogPostListDto = {
 
 export type BlogPostWriteRequest = {
 	title?: string | null;
+	showTitle?: boolean | null;
 	content: string;
 	author?: string | null;
 	launchDateLocal?: string | null;
@@ -50,6 +57,8 @@ export type BlogPostWriteRequest = {
 export type AdminBlogPostDto = {
 	id: number;
 	title?: string | null;
+	showTitle?: boolean;
+	isTitleGenerated?: boolean | null;
 	content: string;
 	author: string;
 	images?: BloggImageDto[] | null;

--- a/Client/src/lib/utils/dates.ts
+++ b/Client/src/lib/utils/dates.ts
@@ -33,9 +33,3 @@ export function toLocalDateTimeInput(value?: string | Date | null) {
 	const local = new Date(date.getTime() - offset * 60_000);
 	return local.toISOString().slice(0, 16);
 }
-
-export function readingMinutes(text?: string | null) {
-	if (!text) return 1;
-	const words = text.replace(/<[^>]*>/g, ' ').trim().split(/\s+/).filter(Boolean).length;
-	return Math.max(1, Math.ceil(words / 220));
-}

--- a/Client/src/routes/admin/forbidden-words/+page.svelte
+++ b/Client/src/routes/admin/forbidden-words/+page.svelte
@@ -21,9 +21,9 @@
 			await createForbiddenWord(getClientFetch(), wordPattern.trim());
 			wordPattern = '';
 			await invalidateAll();
-			toasts.success('Mönster lades till.');
+			toasts.success('Ord/mönster lades till.');
 		} catch (error) {
-			toasts.error(getFriendlyApiMessage(error, 'Monstret kunde inte läggas till.'));
+			toasts.error(getFriendlyApiMessage(error, 'Ord/mönster kunde inte läggas till.'));
 		}
 	}
 
@@ -60,9 +60,9 @@
 		<p class="status-text status-text--error">{data.error}</p>
 	{/if}
 
-	<FormSection title="Lägg till mönster" text="API:t äger själva censur- och säkerhetsreglerna.">
+	<FormSection title="Lägg till ord" text="API:t normaliserar nya ord och bevarar färdiga mönster.">
 		<form class="word-form" on:submit|preventDefault={add}>
-			<FormField label="Regex eller ordmönster" id="word-pattern">
+			<FormField label="Ord eller färdigt mönster" id="word-pattern">
 				<input id="word-pattern" bind:value={wordPattern} />
 			</FormField>
 			<Button type="submit">Lägg till</Button>

--- a/Client/src/routes/blog/[slug]/+page.svelte
+++ b/Client/src/routes/blog/[slug]/+page.svelte
@@ -4,11 +4,13 @@
 	import CommentSection from '$lib/components/comments/CommentSection.svelte';
 
 	export let data;
+
+	$: pageTitle = data.post.title || 'Blogginlägg';
 </script>
 
 <svelte:head>
-	<title>{data.post.title} | SarasBlogg</title>
-	<meta name="description" content={data.post.title} />
+	<title>{pageTitle} | SarasBlogg</title>
+	<meta name="description" content={pageTitle} />
 </svelte:head>
 
 <BlogPost post={data.post} />

--- a/Client/src/routes/profile/+page.svelte
+++ b/Client/src/routes/profile/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import ProfileCard from '$lib/components/auth/ProfileCard.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import FormField from '$lib/components/forms/FormField.svelte';
@@ -6,9 +7,16 @@
 	import { useClientFetch } from '$lib/api/clientFetch';
 	import { getFriendlyApiMessage } from '$lib/api/apiErrors';
 	import { getCurrentUser, mapToFrontendUser } from '$lib/services/authService';
-	import { changeMyUsername, updateMyProfile } from '$lib/services/userService';
+	import {
+		changeMyUsername,
+		deleteMyAccount,
+		downloadMyPersonalData,
+		updateMyProfile
+	} from '$lib/services/userService';
 	import { auth } from '$lib/stores/authStore';
 	import { toasts } from '$lib/stores/toastStore';
+	import { formatDateTime } from '$lib/utils/dates';
+	import { routes } from '$lib/utils/routes';
 
 	export let data;
 
@@ -17,11 +25,15 @@
 	let displayName = data.user.name ?? '';
 	let phoneNumber = data.user.phoneNumber ?? '';
 	let birthYear = data.user.birthYear ?? null;
-	let notifyOnNewPost = data.user.notifyOnNewPost;
 	let newUserName = data.user.userName;
 	let status = '';
 	let error = '';
 	let isSaving = false;
+	let isExporting = false;
+	let isDeleting = false;
+	let deleteDialogOpen = false;
+	let deletePassword = '';
+	let deleteConfirmation = '';
 
 	async function refreshSession() {
 		const me = await getCurrentUser(getClientFetch());
@@ -36,8 +48,7 @@
 			const result = await updateMyProfile(getClientFetch(), {
 				name: displayName || null,
 				phoneNumber: phoneNumber || null,
-				birthYear,
-				notifyOnNewPost
+				birthYear
 			});
 			status = result.message || 'Profilen är uppdaterad.';
 			await refreshSession();
@@ -63,6 +74,61 @@
 			toasts.error(error);
 		}
 	}
+
+	async function exportActivity() {
+		error = '';
+		status = '';
+		isExporting = true;
+		try {
+			const { blob, filename } = await downloadMyPersonalData(getClientFetch());
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = filename;
+			document.body.appendChild(link);
+			link.click();
+			link.remove();
+			setTimeout(() => URL.revokeObjectURL(url), 0);
+			toasts.success('Din dataexport laddas ner.');
+		} catch (err) {
+			error = getFriendlyApiMessage(err, 'Exporten kunde inte hämtas.');
+			toasts.error(error);
+		} finally {
+			isExporting = false;
+		}
+	}
+
+	function openDeleteDialog() {
+		deleteDialogOpen = true;
+		deletePassword = '';
+		deleteConfirmation = '';
+	}
+
+	function closeDeleteDialog() {
+		if (isDeleting) return;
+		deleteDialogOpen = false;
+	}
+
+	async function deleteAccount() {
+		if (deleteConfirmation.trim() !== 'RADERA') return;
+
+		error = '';
+		status = '';
+		isDeleting = true;
+		try {
+			const result = await deleteMyAccount(getClientFetch(), deletePassword || null);
+			auth.clear();
+			deleteDialogOpen = false;
+			toasts.success(result.message || 'Kontot är raderat.');
+			// eslint-disable-next-line svelte/no-navigation-without-resolve
+			await goto(routes.home);
+		} catch (err) {
+			error = getFriendlyApiMessage(err, 'Kontot kunde inte raderas.');
+			toasts.error(error);
+		} finally {
+			isDeleting = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -73,7 +139,7 @@
 	<div class="container profile-grid">
 		<ProfileCard user={data.user} />
 
-		<FormSection title="Dina uppgifter" text="Frontend sparar bara DTO-fält som API:t accepterar.">
+		<FormSection title="Dina uppgifter">
 			<form class="form-grid" on:submit|preventDefault={saveProfile}>
 				<div class="two-column">
 					<FormField label="Namn" id="profile-name">
@@ -84,14 +150,22 @@
 					</FormField>
 				</div>
 				<FormField label="Födelseår" id="profile-birthyear">
-					<input id="profile-birthyear" type="number" min="1900" max="2100" bind:value={birthYear} />
+					<input
+						id="profile-birthyear"
+						type="number"
+						min="1900"
+						max="2100"
+						bind:value={birthYear}
+					/>
 				</FormField>
-				<label class="check"><input type="checkbox" bind:checked={notifyOnNewPost} /> Få mejl vid nya inlägg</label>
 				<Button type="submit" disabled={isSaving}>{isSaving ? 'Sparar...' : 'Spara profil'}</Button>
 			</form>
 		</FormSection>
 
-		<FormSection title="Användarnamn" text="Om Google-kontot skapade ett temporärt användarnamn kan du byta det här.">
+		<FormSection
+			title="Användarnamn"
+			text="Om Google-kontot skapade ett temporärt användarnamn kan du byta det här."
+		>
 			<form class="form-grid" on:submit|preventDefault={saveUsername}>
 				<FormField label="Användarnamn" id="profile-username">
 					<input id="profile-username" bind:value={newUserName} />
@@ -106,8 +180,50 @@
 					<div><strong>{data.personalData.commentsCount}</strong><span>Kommentarer</span></div>
 					<div><strong>{data.personalData.likesCount}</strong><span>Gillningar</span></div>
 				</div>
+				<div class="activity-actions">
+					<Button
+						type="button"
+						variant="secondary"
+						disabled={isExporting}
+						on:click={exportActivity}
+					>
+						{isExporting ? 'Hämtar...' : 'Ladda ner JSON'}
+					</Button>
+				</div>
+				{#if data.personalData.comments?.length}
+					<section class="activity-list" aria-labelledby="profile-comments-title">
+						<h3 id="profile-comments-title">Kommentarer</h3>
+						{#each data.personalData.comments as comment (comment.id)}
+							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+							<a href={`${routes.blog}/${comment.bloggId}`}>
+								<strong>{comment.bloggTitle || `Inlägg #${comment.bloggId}`}</strong>
+								<span>{formatDateTime(comment.createdAt)}</span>
+								<p>{comment.content}</p>
+							</a>
+						{/each}
+					</section>
+				{/if}
+				{#if data.personalData.likes?.length}
+					<section class="activity-list" aria-labelledby="profile-likes-title">
+						<h3 id="profile-likes-title">Gillningar</h3>
+						{#each data.personalData.likes as like (like.id)}
+							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+							<a href={`${routes.blog}/${like.bloggId}`}>
+								<strong>{like.bloggTitle || `Inlägg #${like.bloggId}`}</strong>
+								<span>{formatDateTime(like.createdAt)}</span>
+							</a>
+						{/each}
+					</section>
+				{/if}
 			</FormSection>
 		{/if}
+
+		<FormSection title="Radera konto">
+			<div class="danger-zone">
+				<p>Radering tar bort kontot permanent.</p>
+				<Button type="button" variant="danger" on:click={openDeleteDialog}>Radera konto</Button>
+			</div>
+		</FormSection>
 
 		{#if status}
 			<p class="status-text status-text--success">{status}</p>
@@ -118,18 +234,52 @@
 	</div>
 </section>
 
+{#if deleteDialogOpen}
+	<div class="delete-backdrop" role="presentation">
+		<div
+			class="delete-dialog"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="delete-account-title"
+			aria-describedby="delete-account-message"
+		>
+			<h2 id="delete-account-title">Är du säker?</h2>
+			<p id="delete-account-message">
+				Kontot och din åtkomst tas bort permanent. Detta går inte att ångra.
+			</p>
+			<form class="form-grid" on:submit|preventDefault={deleteAccount}>
+				<FormField label="Skriv RADERA för att bekräfta" id="delete-confirmation">
+					<input id="delete-confirmation" bind:value={deleteConfirmation} autocomplete="off" />
+				</FormField>
+				<FormField label="Lösenord" id="delete-password">
+					<input
+						id="delete-password"
+						type="password"
+						bind:value={deletePassword}
+						autocomplete="current-password"
+					/>
+				</FormField>
+				<div class="delete-actions">
+					<Button type="button" variant="ghost" disabled={isDeleting} on:click={closeDeleteDialog}
+						>Avbryt</Button
+					>
+					<button
+						type="submit"
+						class="delete-submit"
+						disabled={deleteConfirmation.trim() !== 'RADERA' || isDeleting}
+					>
+						{isDeleting ? 'Raderar...' : 'Radera permanent'}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+{/if}
+
 <style>
 	.profile-grid {
 		display: grid;
 		gap: 1.25rem;
-	}
-
-	.check {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		color: var(--color-muted);
-		font-weight: 800;
 	}
 
 	.activity-grid {
@@ -155,5 +305,127 @@
 	.activity-grid span {
 		color: var(--color-muted);
 		font-weight: 800;
+	}
+
+	.activity-actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 1rem;
+	}
+
+	.activity-list {
+		display: grid;
+		gap: 0.65rem;
+		margin-top: 1.1rem;
+	}
+
+	.activity-list h3 {
+		margin: 0;
+		color: var(--color-heading);
+		font-family: var(--font-serif);
+		font-size: 1.45rem;
+	}
+
+	.activity-list a {
+		display: grid;
+		gap: 0.2rem;
+		padding: 0.85rem 0;
+		border-top: 1px solid var(--color-border);
+	}
+
+	.activity-list strong {
+		color: var(--color-heading);
+	}
+
+	.activity-list span,
+	.activity-list p,
+	.danger-zone p,
+	.delete-dialog p {
+		margin: 0;
+		color: var(--color-muted);
+	}
+
+	.activity-list p {
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		overflow: hidden;
+	}
+
+	.danger-zone {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.delete-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 90;
+		display: grid;
+		place-items: center;
+		padding: 1rem;
+		background: rgba(72, 54, 40, 0.32);
+		backdrop-filter: blur(5px);
+	}
+
+	.delete-dialog {
+		width: min(100%, 470px);
+		padding: 1.35rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-card);
+		background: var(--color-surface);
+		box-shadow: var(--shadow-soft);
+	}
+
+	.delete-dialog h2 {
+		margin: 0;
+		color: var(--color-heading);
+		font-family: var(--font-serif);
+		font-size: 2.1rem;
+		line-height: 1.05;
+	}
+
+	.delete-dialog form {
+		margin-top: 1rem;
+	}
+
+	.delete-actions {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		gap: 0.65rem;
+	}
+
+	.delete-submit {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 2.7rem;
+		padding: 0.72rem 1.15rem;
+		border: 1px solid transparent;
+		border-radius: 999px;
+		background: #9b3f35;
+		color: #fffaf4;
+		font-size: 0.88rem;
+		font-weight: 800;
+		letter-spacing: 0.04em;
+		line-height: 1;
+		text-transform: uppercase;
+		box-shadow: 0 12px 26px rgba(111, 79, 44, 0.2);
+	}
+
+	.delete-submit:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	@media (max-width: 620px) {
+		.activity-grid {
+			grid-template-columns: 1fr;
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary

Improves Svelte frontend parity with the mature Razor experience while keeping the API as the source of truth.

This PR focuses on:
- forbidden word normalization
- profile cleanup/features
- blog title behavior
- consistent reading time handling
- small UX improvements

---

## API Changes

### Forbidden words
- moved normalization responsibility into the API layer
- API now accepts:
  - plain words
  - existing regex-like patterns
- existing DB values remain compatible

### Blog metadata
Added:
- showTitle
- isTitleGenerated
- readingTimeMinutes

This separates:
- storage metadata
- generated fallback titles
- presentation behavior

Reading time is now API-provided and consistent across clients.

### Migration
Added migration:
AddBlogTitleMetadata

Existing posts:
- default to ShowTitle = false
- preserve backward compatibility

---

## Svelte Changes

### Profile page
- removed misleading DTO/API helper text
- removed inactive email notification toggle
- added activity/data export
- added delete account flow with explicit confirmation modal

### Blog rendering
- cards and detail pages now use shared API reading time
- titles only render when explicitly enabled
- removed inconsistent client-side reading calculations

### Admin editor
- added explicit “Visa titel i inlägget” toggle

---

## Razor Compatibility

No Razor behavior regressions intended.

Razor:
- still works with existing forbidden word regex patterns
- does not need to send showTitle
- preserves current behavior by default

No Razor-specific auth or routing behavior changed.

---

## Verification

Passed:
- dotnet build API/SarasBloggAPI.csproj --no-restore
- dotnet build APITests/APITests.csproj --no-restore
- dotnet test APITests/APITests.csproj --no-build
- npm run check
- npm run build

Notes:
- full lint still reports existing unrelated Prettier drift outside touched files