### PR TITLE
fix(svelte): stabilize mobile auth restore and close mobile menu on n…

### DIFF
--- a/Client/src/lib/components/layout/Navbar.svelte
+++ b/Client/src/lib/components/layout/Navbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import BrandLockup from '$lib/components/brand/BrandLockup.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -13,6 +13,10 @@
 	const getClientFetch = useClientFetch();
 
 	let open = false;
+
+	afterNavigate(() => {
+		open = false;
+	});
 
 	const navItems = [
 		{ href: routes.home, label: 'Hem' },

--- a/Client/src/routes/auth/external/callback/+page.svelte
+++ b/Client/src/routes/auth/external/callback/+page.svelte
@@ -5,15 +5,35 @@
 	import AuthPanel from '$lib/components/auth/AuthPanel.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import { getFriendlyApiMessage } from '$lib/api/apiErrors';
-	import { exchangeExternalLoginCode } from '$lib/services/authService';
+	import { exchangeExternalLoginCode, getCurrentUser } from '$lib/services/authService';
 	import { toasts } from '$lib/stores/toastStore';
 	import { ensureBasePath, isSafeLocalPath, routes } from '$lib/utils/routes';
 
 	let error = '';
+	const sessionRestoreDelays = [80, 160, 320, 640];
 
 	function safeReturnUrl(value: string | null) {
 		if (!isSafeLocalPath(value)) return routes.home;
 		return ensureBasePath(value);
+	}
+
+	function delay(ms: number) {
+		return new Promise((resolve) => setTimeout(resolve, ms));
+	}
+
+	async function waitForSessionRestore(fetchFn: typeof fetch) {
+		for (const delayMs of sessionRestoreDelays) {
+			await delay(delayMs);
+
+			try {
+				const user = await getCurrentUser(fetchFn);
+				if (user) return true;
+			} catch {
+				// The final document navigation below still gives the browser a fresh session read.
+			}
+		}
+
+		return false;
 	}
 
 	onMount(async () => {
@@ -26,10 +46,16 @@
 		}
 
 		try {
-			await exchangeExternalLoginCode(window.fetch.bind(window), code);
-			await invalidate('auth:session');
+			const fetchFn = window.fetch.bind(window);
+			await exchangeExternalLoginCode(fetchFn, code);
+			const sessionRestored = await waitForSessionRestore(fetchFn);
 			toasts.success('Du är inloggad.');
-			await goto(returnUrl, { replaceState: true });
+			if (sessionRestored) {
+				await invalidate('auth:session');
+				await goto(returnUrl, { replaceState: true, invalidateAll: true });
+				return;
+			}
+			window.location.replace(returnUrl);
 		} catch (err) {
 			error = getFriendlyApiMessage(err, 'Google-inloggningen kunde inte slutföras.');
 			toasts.error(error);


### PR DESCRIPTION
Summary

Fixes unstable Google login/session restoration on mobile Safari in the Svelte frontend and improves mobile navigation behavior.

This is a Svelte-only fix. Razor and API auth flows remain unchanged.

Changes

* Stabilized external auth session restoration after Google login
* Added fallback handling for delayed mobile cookie/session availability
* Invalidates auth session state before navigation after exchange
* Forces fresh navigation state after successful auth restore
* Closes mobile menu automatically after navigation completes

Technical Notes

The issue was caused by a race between:

* external login exchange
* cookie/session availability on mobile Safari
* SvelteKit parent auth invalidation/navigation timing

The callback flow now:

1. Exchanges external login code
2. Waits for session visibility
3. Invalidates auth:session
4. Navigates with fresh state
5. Falls back to full document navigation if needed

Scope

Affected files:

* Client/src/routes/auth/external/callback/+page.svelte
* Client/src/lib/components/layout/Navbar.svelte

Verification

* npm run check passed
* Prettier passed on changed files
* git diff --check passed

Notes

* No Razor changes
* No API contract changes
* Existing repo-wide Prettier drift remains untouched