### PR TITLE
fix(svelte): use full page auth restore after external login

### DIFF
--- a/Client/src/routes/auth/external/callback/+page.svelte
+++ b/Client/src/routes/auth/external/callback/+page.svelte
@@ -1,39 +1,18 @@
 <script lang="ts">
-	import { goto, invalidate } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
 	import AuthPanel from '$lib/components/auth/AuthPanel.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import { getFriendlyApiMessage } from '$lib/api/apiErrors';
-	import { exchangeExternalLoginCode, getCurrentUser } from '$lib/services/authService';
+	import { exchangeExternalLoginCode } from '$lib/services/authService';
 	import { toasts } from '$lib/stores/toastStore';
 	import { ensureBasePath, isSafeLocalPath, routes } from '$lib/utils/routes';
 
 	let error = '';
-	const sessionRestoreDelays = [80, 160, 320, 640];
 
 	function safeReturnUrl(value: string | null) {
 		if (!isSafeLocalPath(value)) return routes.home;
 		return ensureBasePath(value);
-	}
-
-	function delay(ms: number) {
-		return new Promise((resolve) => setTimeout(resolve, ms));
-	}
-
-	async function waitForSessionRestore(fetchFn: typeof fetch) {
-		for (const delayMs of sessionRestoreDelays) {
-			await delay(delayMs);
-
-			try {
-				const user = await getCurrentUser(fetchFn);
-				if (user) return true;
-			} catch {
-				// The final document navigation below still gives the browser a fresh session read.
-			}
-		}
-
-		return false;
 	}
 
 	onMount(async () => {
@@ -48,13 +27,7 @@
 		try {
 			const fetchFn = window.fetch.bind(window);
 			await exchangeExternalLoginCode(fetchFn, code);
-			const sessionRestored = await waitForSessionRestore(fetchFn);
 			toasts.success('Du är inloggad.');
-			if (sessionRestored) {
-				await invalidate('auth:session');
-				await goto(returnUrl, { replaceState: true, invalidateAll: true });
-				return;
-			}
 			window.location.replace(returnUrl);
 		} catch (err) {
 			error = getFriendlyApiMessage(err, 'Google-inloggningen kunde inte slutföras.');


### PR DESCRIPTION
Summary

Reworks the Svelte external login completion flow to use a document-level auth restore instead of SPA auth restoration after Google login.

This targets intermittent iOS Safari/mobile authentication issues where login succeeds backend-side but the Svelte frontend remains logged out due to delayed cross-origin cookie availability.

Changes

* Removed SPA auth restore sequence after external login exchange
* Removed:
    * polling
    * invalidate('auth:session')
    * goto(...)
* Added hard document navigation using:
    * window.location.replace(returnUrl)
* Preserved:
    * returnUrl behavior
    * GitHub Pages base-path handling
    * callbackPath architecture
    * Razor compatibility
    * API contracts

Why

Safari/iOS appears to delay or inconsistently expose the cross-origin auth cookie immediately after SPA-based exchange flows.

Using a full document navigation after successful exchange aligns the Svelte flow more closely with the already stable Razor flow and avoids stale SvelteKit auth state during SPA lifecycle restoration.

Scope

Modified:

* Client/src/routes/auth/external/callback/+page.svelte

Verification

* npm run check passed
* npm run build passed
* ESLint passed for modified file
* Prettier passed for modified file
* git diff --check passed

Notes

* No Razor changes
* No API changes
* No auth contract changes
* Existing unrelated repo-wide lint/prettier drift remains untouched