### PR TITLE
fix(svelte): finalize external auth before full reload redirect

### DIFF
--- a/Client/src/routes/auth/external/callback/+page.svelte
+++ b/Client/src/routes/auth/external/callback/+page.svelte
@@ -9,10 +9,15 @@
 	import { ensureBasePath, isSafeLocalPath, routes } from '$lib/utils/routes';
 
 	let error = '';
+	const exchangeCommitDelayMs = 250;
 
 	function safeReturnUrl(value: string | null) {
 		if (!isSafeLocalPath(value)) return routes.home;
 		return ensureBasePath(value);
+	}
+
+	function allowExchangeResponseToSettle() {
+		return new Promise((resolve) => setTimeout(resolve, exchangeCommitDelayMs));
 	}
 
 	onMount(async () => {
@@ -27,6 +32,7 @@
 		try {
 			const fetchFn = window.fetch.bind(window);
 			await exchangeExternalLoginCode(fetchFn, code);
+			await allowExchangeResponseToSettle();
 			toasts.success('Du är inloggad.');
 			window.location.replace(returnUrl);
 		} catch (err) {


### PR DESCRIPTION
Summary

Fixes a regression in the Svelte external Google login callback flow where authentication could fail before the backend exchange fully completed.

This keeps the document-level auth restore approach while ensuring the external exchange and cookie commit complete before redirecting.

Changes

* Fully awaits external login exchange before redirect
* Added a short post-exchange settle delay before:
    * window.location.replace(returnUrl)
* Keeps:
    * full document auth restore flow
    * GitHub Pages base-path handling
    * returnUrl preservation
    * callbackPath architecture

Removed Complexity

Still intentionally avoids:

* polling
* invalidate('auth:session')
* goto(...)
* extra auth fetches after exchange

Why

Mobile Safari/iOS appears sensitive to immediate navigation directly after cross-origin auth exchange responses.

The small settle delay allows the browser to finish processing the exchange response and associated HttpOnly cookie before document navigation begins.

Scope

Modified:

* Client/src/routes/auth/external/callback/+page.svelte

Verification

* npm run check passed
* ESLint passed
* Prettier passed
* npm run build passed
* git diff --check passed

Notes

* No Razor changes
* No API changes
* No auth contract changes
* Existing unrelated repo-wide lint/prettier drift remains untouched