### PR TITLE
fix(svelte): isolate external auth callback from app auth lifecycle

### DIFF
--- a/Client/src/routes/+layout.svelte
+++ b/Client/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import CookieConsent from '$lib/components/layout/CookieConsent.svelte';
 	import Toast from '$lib/components/ui/Toast.svelte';
 	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte';
+	import { page } from '$app/stores';
 	import { brand } from '$lib/config/site';
 	import { auth } from '$lib/stores/authStore';
 	import { staticAsset } from '$lib/utils/routes';
@@ -16,7 +17,15 @@
 	const appShellStyle = `--app-flower-top-left: url("${topLeftFlower}"); --app-flower-bottom-right: url("${bottomRightFlower}");`;
 	let cookieConsent: CookieConsent;
 
-	$: auth.setUser(data.user ?? null);
+	function isExternalAuthCallbackPath(pathname: string) {
+		return pathname.replace(/\/+$/, '').endsWith('/auth/external/callback');
+	}
+
+	$: isExternalAuthCallback =
+		data.isExternalAuthCallback ?? isExternalAuthCallbackPath($page.url.pathname);
+	$: if (!isExternalAuthCallback) {
+		auth.setUser(data.user ?? null);
+	}
 </script>
 
 <svelte:head>
@@ -24,13 +33,17 @@
 	<meta name="theme-color" content="#fbf4ea" />
 </svelte:head>
 
-<div class="app-shell" style={appShellStyle}>
-	<Navbar />
-	<main class="page-main">
-		<slot />
-	</main>
-	<Footer on:privacy={() => cookieConsent?.openPrivacy()} />
-	<CookieConsent bind:this={cookieConsent} />
-	<Toast />
-	<ConfirmDialog />
-</div>
+{#if isExternalAuthCallback}
+	<slot />
+{:else}
+	<div class="app-shell" style={appShellStyle}>
+		<Navbar />
+		<main class="page-main">
+			<slot />
+		</main>
+		<Footer on:privacy={() => cookieConsent?.openPrivacy()} />
+		<CookieConsent bind:this={cookieConsent} />
+		<Toast />
+		<ConfirmDialog />
+	</div>
+{/if}

--- a/Client/src/routes/+layout.ts
+++ b/Client/src/routes/+layout.ts
@@ -1,16 +1,29 @@
 import { getCurrentUser, mapToFrontendUser } from '$lib/services/authService';
 
-export const load = async ({ depends, fetch }) => {
+function isExternalAuthCallbackPath(pathname: string) {
+	return pathname.replace(/\/+$/, '').endsWith('/auth/external/callback');
+}
+
+export const load = async ({ depends, fetch, url }) => {
+	if (isExternalAuthCallbackPath(url.pathname)) {
+		return {
+			user: null,
+			isExternalAuthCallback: true
+		};
+	}
+
 	depends('auth:session');
 
 	try {
 		const me = await getCurrentUser(fetch);
 		return {
-			user: me ? mapToFrontendUser(me) : null
+			user: me ? mapToFrontendUser(me) : null,
+			isExternalAuthCallback: false
 		};
 	} catch {
 		return {
-			user: null
+			user: null,
+			isExternalAuthCallback: false
 		};
 	}
 };

--- a/Client/src/routes/login/+page.svelte
+++ b/Client/src/routes/login/+page.svelte
@@ -16,7 +16,7 @@
 		window.location.href = getGoogleLoginUrl(
 			window.location.origin,
 			returnUrl,
-			`${base}/auth/external/callback`
+			`${base}/auth/external/callback/`
 		);
 	}
 </script>


### PR DESCRIPTION
Summary

Fixes the remaining Svelte external Google login instability by isolating the external callback route from the normal SvelteKit auth/layout lifecycle during exchange and hydration.

This prevents the callback flow from inheriting temporary logged-out state while the one-time external auth exchange is still in progress.

Root Cause

The external callback route still participated in the normal root auth lifecycle:

* root +layout.ts restored user = null
* root +layout.svelte synced that state into the auth store
* callback rendered inside the normal logged-out app shell
* exchange flow and auth restoration raced during initialization

Additionally, the callback route required a trailing slash while the login page used a callback path without one.

Changes

Callback lifecycle isolation

* Skips root auth restore and depends('auth:session') for:
    * /auth/external/callback/

App shell isolation

* Callback route no longer renders:
    * normal navbar
    * footer
    * logged-out shell UI
* Prevents temporary user=null auth-store synchronization during callback exchange.

Callback path consistency

* Updated callback path to:
    * /auth/external/callback/
* Matches route trailing-slash configuration.

Auth flow

The callback flow remains intentionally minimal:

await exchangeExternalLoginCode(...)
→ short settle delay
→ window.location.replace(returnUrl)

No:

* polling
* invalidate
* goto
* API changes
* Razor changes

Modified Files

* Client/src/routes/+layout.ts
* Client/src/routes/+layout.svelte
* Client/src/routes/login/+page.svelte

Verification

* npm run check passed
* ESLint passed on modified files
* Prettier passed on modified files
* Production build passed
* git diff --check passed

Notes

* Razor frontend untouched
* API contracts untouched
* GitHub Pages base-path support preserved
* Existing unrelated repo-wide Prettier drift remains untouched