### PR TITLE
feat(svelte): add temporary hybrid auth compatibility layer

### DIFF
--- a/Client/src/lib/api/apiClient.ts
+++ b/Client/src/lib/api/apiClient.ts
@@ -1,4 +1,5 @@
 import { createApiError } from './apiErrors';
+import { getTemporarySvelteAccessToken } from './temporarySvelteAuth';
 
 export type ApiFetch = typeof fetch;
 
@@ -66,6 +67,16 @@ export async function apiRequest<T>(
 	if (hasBody && !isFormData && !headers.has('Content-Type')) {
 		headers.set('Content-Type', 'application/json');
 	}
+	const temporaryAccessToken = getTemporarySvelteAccessToken();
+	if (temporaryAccessToken && !headers.has('Authorization')) {
+		// TEMPORARY SVELTE SPA COMPATIBILITY LAYER:
+		// Mobile Safari/WebKit may reject the Render API's cross-site HttpOnly cookie
+		// when Svelte runs on GitHub Pages. Prefer the short-lived access token returned
+		// by the existing API login/exchange response for Svelte requests only. Cookie
+		// auth stays enabled via credentials: 'include' and Razor remains unchanged.
+		// Remove this when Svelte and API are same-site or a BFF/server-auth flow exists.
+		headers.set('Authorization', `Bearer ${temporaryAccessToken}`);
+	}
 
 	const response = await fetchFn(resolveApiUrl(path), {
 		...options,
@@ -98,6 +109,10 @@ export async function apiDownload(
 
 	const headers = new Headers(options.headers);
 	if (!headers.has('Accept')) headers.set('Accept', '*/*');
+	const temporaryAccessToken = getTemporarySvelteAccessToken();
+	if (temporaryAccessToken && !headers.has('Authorization')) {
+		headers.set('Authorization', `Bearer ${temporaryAccessToken}`);
+	}
 
 	const response = await fetchFn(resolveApiUrl(path), {
 		...init,

--- a/Client/src/lib/api/temporarySvelteAuth.ts
+++ b/Client/src/lib/api/temporarySvelteAuth.ts
@@ -1,0 +1,79 @@
+import { browser } from '$app/environment';
+
+type TemporarySvelteAccessToken = {
+	accessToken: string;
+	accessTokenExpiresUtc: string;
+};
+
+const storageKey = 'sarasblogg.temporarySvelteAccessToken';
+let memoryToken: TemporarySvelteAccessToken | null = null;
+
+function isExpired(token: TemporarySvelteAccessToken) {
+	const expiresAt = Date.parse(token.accessTokenExpiresUtc);
+	return Number.isNaN(expiresAt) || expiresAt <= Date.now();
+}
+
+function readStoredToken() {
+	if (!browser) return null;
+
+	const raw = sessionStorage.getItem(storageKey);
+	if (!raw) return null;
+
+	try {
+		const parsed = JSON.parse(raw) as TemporarySvelteAccessToken;
+		if (!parsed.accessToken || !parsed.accessTokenExpiresUtc || isExpired(parsed)) {
+			clearTemporarySvelteAccessToken();
+			return null;
+		}
+
+		memoryToken = parsed;
+		return parsed;
+	} catch {
+		clearTemporarySvelteAccessToken();
+		return null;
+	}
+}
+
+export function getTemporarySvelteAccessToken() {
+	const token = memoryToken ?? readStoredToken();
+	if (!token) return null;
+
+	if (isExpired(token)) {
+		clearTemporarySvelteAccessToken();
+		return null;
+	}
+
+	return token.accessToken;
+}
+
+export function setTemporarySvelteAccessToken(
+	accessToken: string,
+	accessTokenExpiresUtc: string | Date
+) {
+	const token = {
+		accessToken,
+		accessTokenExpiresUtc:
+			accessTokenExpiresUtc instanceof Date
+				? accessTokenExpiresUtc.toISOString()
+				: accessTokenExpiresUtc
+	};
+
+	memoryToken = token;
+
+	if (browser) {
+		// TEMPORARY SVELTE SPA COMPATIBILITY LAYER:
+		// The current GitHub Pages + Render deployment makes the API cookie third-party
+		// from the Svelte app's point of view. Mobile Safari/WebKit can block or drop
+		// that cross-site HttpOnly cookie even when CORS and SameSite=None are correct.
+		// Keep only the short-lived access token in memory/sessionStorage so the SPA can
+		// send Authorization: Bearer until Svelte moves to same-site hosting, a shared
+		// custom domain, or a proper BFF/server-auth flow. Do not persist refresh tokens
+		// or move this into long-term localStorage auth.
+		sessionStorage.setItem(storageKey, JSON.stringify(token));
+	}
+}
+
+export function clearTemporarySvelteAccessToken() {
+	memoryToken = null;
+	if (browser) sessionStorage.removeItem(storageKey);
+}

--- a/Client/src/lib/services/authService.ts
+++ b/Client/src/lib/services/authService.ts
@@ -1,4 +1,8 @@
 import { apiGet, apiPost, getExternalApiBaseUrl, type ApiFetch } from '$lib/api/apiClient';
+import {
+	clearTemporarySvelteAccessToken,
+	setTemporarySvelteAccessToken
+} from '$lib/api/temporarySvelteAuth';
 import type {
 	AuthSessionDto,
 	BasicResultDto,
@@ -51,11 +55,13 @@ export async function login(
 	password: string,
 	rememberMe = true
 ): Promise<LoginResponse> {
-	return apiPost<LoginResponse>(fetchFn, '/api/auth/login', {
+	const response = await apiPost<LoginResponse>(fetchFn, '/api/auth/login', {
 		userNameOrEmail,
 		password,
 		rememberMe
 	});
+	setTemporarySvelteAccessToken(response.accessToken, response.accessTokenExpiresUtc);
+	return response;
 }
 
 export async function register(
@@ -66,14 +72,20 @@ export async function register(
 }
 
 export async function logout(fetchFn: ApiFetch): Promise<void> {
-	await apiPost<void>(fetchFn, '/api/auth/logout', undefined, { emptyResponse: true });
+	try {
+		await apiPost<void>(fetchFn, '/api/auth/logout', undefined, { emptyResponse: true });
+	} finally {
+		clearTemporarySvelteAccessToken();
+	}
 }
 
 export async function exchangeExternalLoginCode(
 	fetchFn: ApiFetch,
 	code: string
 ): Promise<LoginResponse> {
-	return apiPost<LoginResponse>(fetchFn, '/api/auth/external/exchange', { code });
+	const response = await apiPost<LoginResponse>(fetchFn, '/api/auth/external/exchange', { code });
+	setTemporarySvelteAccessToken(response.accessToken, response.accessTokenExpiresUtc);
+	return response;
 }
 
 export function getGoogleLoginUrl(

--- a/Client/src/lib/stores/authStore.ts
+++ b/Client/src/lib/stores/authStore.ts
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
+import { clearTemporarySvelteAccessToken } from '$lib/api/temporarySvelteAuth';
 import type { FrontendUser, Role } from '$lib/types/auth';
 
 type AuthState = {
@@ -28,6 +29,7 @@ function createAuthStore() {
 	}
 
 	function clear() {
+		clearTemporarySvelteAccessToken();
 		set({ user: null, isLoading: false });
 	}
 


### PR DESCRIPTION
Summary

Adds a temporary Svelte-only hybrid auth compatibility layer to stabilize authentication on mobile browsers during the current GitHub Pages + Render deployment setup.

This works around mobile Safari/WebKit third-party cookie restrictions affecting cross-origin API cookie persistence after Google login.

Razor and API auth behavior remain unchanged.

Why

Current deployment topology:

GitHub Pages (Svelte)
↔
Render API

causes mobile browsers, especially Safari/WebKit, to inconsistently persist or send cross-origin HttpOnly cookies after the external login exchange flow.

Desktop browsers were more permissive, while mobile browsers frequently appeared logged out despite successful backend authentication.

What Changed
Temporary Svelte auth layer

Added:

Client/src/lib/api/temporarySvelteAuth.ts

Behavior:

stores access token primarily in memory
mirrors token to sessionStorage for reload persistence
stores only:
accessToken
token expiry
does NOT persist refresh tokens
automatically clears expired/bad tokens
API client compatibility

Updated:

Client/src/lib/api/apiClient.ts

Behavior:

sends:
Authorization: Bearer {token}
when temporary Svelte auth exists
keeps:
credentials: 'include'
for existing cookie compatibility and future same-site deployment
Auth integration

Updated:

Client/src/lib/services/authService.ts
Client/src/lib/stores/authStore.ts

Behavior:

login/external exchange store temporary token
logout/auth clear removes temporary token
Scope

This is intentionally:

temporary
Svelte-only
isolated
minimally invasive

No:

Razor changes
API contract changes
auth authority changes
backend role/claim ownership changes
Future Removal Path

This compatibility layer should be removed later when:

Svelte runs on same-site hosting
custom domain + same-site API is used
or a proper BFF/server-auth flow is implemented

Removal is isolated and documented in code comments.

Verification
npm run check passed
production build passed
existing cookie auth compatibility preserved
centralized API/service architecture preserved
Notes

This is a pragmatic compatibility bridge for current deployment constraints, not a permanent replacement for the existing API-first cookie auth architecture.