### PR TITLE
fix(svelte-auth): stabilize username setup and session refresh flow

### DIFF
--- a/API/Controllers/Auth/AuthController.cs
+++ b/API/Controllers/Auth/AuthController.cs
@@ -312,11 +312,11 @@ public class AuthController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<MeResponse>> Me()
     {
-        var userName = User?.Identity?.Name;
-        if (string.IsNullOrWhiteSpace(userName))
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
             return Unauthorized();
 
-        var user = await _userManager.FindByNameAsync(userName);
+        var user = await _userManager.FindByIdAsync(userId);
         if (user is null)
             return Unauthorized();
 
@@ -982,6 +982,8 @@ public class AuthController : ControllerBase
         var accessToken = await _tokenService.CreateAccessTokenAsync(user);
         var accessTokenExpiresUtc = DateTime.UtcNow.AddMinutes(
             int.Parse(_cfg["Jwt:AccessTokenMinutes"] ?? "60"));
+
+        AppendApiAccessTokenCookie(accessToken, accessTokenExpiresUtc);
 
         return Ok(new AccessTokenDto
         {

--- a/Client/src/lib/components/auth/ProfileCard.svelte
+++ b/Client/src/lib/components/auth/ProfileCard.svelte
@@ -6,11 +6,11 @@
 </script>
 
 <article class="profile-card card">
-	<div class="avatar" aria-hidden="true">{initials(user.displayName)}</div>
+	<div class="avatar" aria-hidden="true">{initials(user.userName)}</div>
 	<div>
 		<p class="eyebrow">Profil</p>
-		<h1>{user.displayName}</h1>
-		<p>{user.email || user.userName}</p>
+		<h1>{user.userName}</h1>
+		<p>{user.email}</p>
 		<div class="roles">
 			{#each user.roles as role}
 				<span class="badge badge--sage">{role}</span>

--- a/Client/src/lib/components/comments/CommentSection.svelte
+++ b/Client/src/lib/components/comments/CommentSection.svelte
@@ -82,6 +82,11 @@
 	function showOlder() {
 		visibleOlderCount = Math.min(olderComments.length, visibleOlderCount + 10);
 	}
+
+	function commentAuthorName(comment: CommentDto) {
+		if (comment.ownedByCurrentUser && $auth.user) return $auth.user.userName;
+		return comment.name;
+	}
 </script>
 
 <section class="comments" id="comments">
@@ -94,7 +99,7 @@
 
 		<form class="comment-form card" on:submit|preventDefault={submitComment}>
 			{#if $auth.user}
-				<p class="signed-in">Skriver som <strong>{$auth.user.displayName}</strong></p>
+				<p class="signed-in">Skriver som <strong>{$auth.user.userName}</strong></p>
 			{/if}
 			{#if !$auth.user}
 				<FormField label="Namn" id="comment-name">
@@ -124,7 +129,7 @@
 				{#each [...visibleOlderComments, ...recentComments] as comment (comment.id)}
 					<article class="comment">
 						<div>
-							<strong>{comment.name}</strong>
+							<strong>{commentAuthorName(comment)}</strong>
 							<span>{formatDateTime(comment.createdAt)}</span>
 							{#if comment.topRole}
 								<em>{comment.topRole}</em>

--- a/Client/src/lib/components/layout/Navbar.svelte
+++ b/Client/src/lib/components/layout/Navbar.svelte
@@ -94,7 +94,7 @@
 
 		<div class="desktop-actions">
 			{#if user}
-				<a class="profile-link" href={routes.profile}>{user.displayName}</a>
+				<a class="profile-link" href={routes.profile}>{user.userName}</a>
 				<button
 					class="icon-button"
 					type="button"
@@ -123,7 +123,7 @@
 		<MobileMenu
 			{open}
 			{path}
-			userName={user?.displayName ?? null}
+			userName={user?.userName ?? null}
 			roles={user?.roles ?? []}
 			{loginHref}
 			onNavigate={closeMenu}

--- a/Client/src/lib/services/authService.ts
+++ b/Client/src/lib/services/authService.ts
@@ -5,6 +5,7 @@ import {
 } from '$lib/api/temporarySvelteAuth';
 import type {
 	AuthSessionDto,
+	AccessTokenResponse,
 	BasicResultDto,
 	FrontendUser,
 	LoginResponse,
@@ -22,7 +23,6 @@ export function mapToFrontendUser(me: AuthSessionDto): FrontendUser {
 	return {
 		id: me.id,
 		userName: me.userName,
-		displayName: me.name?.trim() || me.userName,
 		email: me.email ?? '',
 		emailConfirmed: me.emailConfirmed,
 		roles,
@@ -47,6 +47,16 @@ export async function getCurrentUser(fetchFn: ApiFetch): Promise<AuthSessionDto 
 		}
 		throw error;
 	}
+}
+
+export async function refreshSession(fetchFn: ApiFetch): Promise<AccessTokenResponse> {
+	const response = await apiPost<AccessTokenResponse>(
+		fetchFn,
+		'/api/auth/refresh-session',
+		undefined
+	);
+	setTemporarySvelteAccessToken(response.accessToken, response.accessTokenExpiresUtc);
+	return response;
 }
 
 export async function login(

--- a/Client/src/lib/stores/authStore.ts
+++ b/Client/src/lib/stores/authStore.ts
@@ -14,6 +14,10 @@ const roleHierarchy: Record<Role, number> = {
 	superadmin: 4
 };
 
+function sameUser(a: FrontendUser | null, b: FrontendUser | null) {
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
 function createAuthStore() {
 	const { subscribe, set, update } = writable<AuthState>({
 		user: null,
@@ -21,7 +25,10 @@ function createAuthStore() {
 	});
 
 	function setUser(user: FrontendUser | null) {
-		set({ user, isLoading: false });
+		update((state) => {
+			if (!state.isLoading && sameUser(state.user, user)) return state;
+			return { user, isLoading: false };
+		});
 	}
 
 	function setLoading(isLoading: boolean) {

--- a/Client/src/lib/types/auth.ts
+++ b/Client/src/lib/types/auth.ts
@@ -13,6 +13,11 @@ export type LoginResponse = {
 	refreshTokenExpiresUtc: string;
 };
 
+export type AccessTokenResponse = {
+	accessToken: string;
+	accessTokenExpiresUtc: string;
+};
+
 export type RegisterRequest = {
 	userName: string;
 	email: string;
@@ -44,7 +49,6 @@ export type AuthSessionDto = {
 export type FrontendUser = {
 	id: string;
 	userName: string;
-	displayName: string;
 	email: string;
 	emailConfirmed: boolean;
 	roles: Role[];

--- a/Client/src/lib/utils/routes.ts
+++ b/Client/src/lib/utils/routes.ts
@@ -1,5 +1,4 @@
 import { base } from '$app/paths';
-import { browser } from '$app/environment';
 import type { BlogPostSummaryDto, BlogPostDetailDto } from '$lib/types/blog';
 
 function appRoute(path: string) {
@@ -27,9 +26,15 @@ export function ensureBasePath(path: string) {
 }
 
 export function routePathFromUrl(url: URL) {
-	const search = browser ? url.search : '';
-	const hash = browser ? url.hash : '';
-	return `${url.pathname}${search}${hash}`;
+	let search = '';
+
+	try {
+		search = url.search;
+	} catch {
+		search = '';
+	}
+
+	return `${url.pathname}${search}`;
 }
 
 export function staticAsset(path: string) {
@@ -61,6 +66,7 @@ export const routes = {
 	login: appRoute('/login'),
 	register: appRoute('/register'),
 	profile: appRoute('/profile'),
+	profileUsername: appRoute('/profile/username'),
 	admin: appRoute('/admin'),
 	adminPosts: appRoute('/admin/posts'),
 	adminComments: appRoute('/admin/comments'),

--- a/Client/src/routes/+layout.ts
+++ b/Client/src/routes/+layout.ts
@@ -1,10 +1,32 @@
+import { redirect } from '@sveltejs/kit';
 import { getCurrentUser, mapToFrontendUser } from '$lib/services/authService';
+import type { FrontendUser } from '$lib/types/auth';
+import { routes } from '$lib/utils/routes';
+
+export const ssr = false;
 
 function isExternalAuthCallbackPath(pathname: string) {
 	return pathname.replace(/\/+$/, '').endsWith('/auth/external/callback');
 }
 
-export const load = async ({ depends, fetch, url }) => {
+function normalizePath(pathname: string) {
+	const normalized = pathname.replace(/\/+$/, '');
+	return normalized || '/';
+}
+
+function isPath(pathname: string, route: string) {
+	return normalizePath(pathname) === normalizePath(route);
+}
+
+function shouldSkipUsernameSetupRedirect(pathname: string) {
+	return (
+		isExternalAuthCallbackPath(pathname) ||
+		isPath(pathname, routes.profileUsername) ||
+		isPath(pathname, routes.login)
+	);
+}
+
+export const load = async ({ fetch, url }) => {
 	if (isExternalAuthCallbackPath(url.pathname)) {
 		return {
 			user: null,
@@ -12,18 +34,22 @@ export const load = async ({ depends, fetch, url }) => {
 		};
 	}
 
-	depends('auth:session');
+	let user: FrontendUser | null = null;
 
 	try {
 		const me = await getCurrentUser(fetch);
-		return {
-			user: me ? mapToFrontendUser(me) : null,
-			isExternalAuthCallback: false
-		};
+		user = me ? mapToFrontendUser(me) : null;
 	} catch {
-		return {
-			user: null,
-			isExternalAuthCallback: false
-		};
+		user = null;
 	}
+
+	if (user?.requiresUsernameSetup && !shouldSkipUsernameSetupRedirect(url.pathname)) {
+		const returnUrl = `${url.pathname}${url.search}`;
+		throw redirect(303, `${routes.profileUsername}?returnUrl=${encodeURIComponent(returnUrl)}`);
+	}
+
+	return {
+		user,
+		isExternalAuthCallback: false
+	};
 };

--- a/Client/src/routes/profile/+page.svelte
+++ b/Client/src/routes/profile/+page.svelte
@@ -6,7 +6,7 @@
 	import FormSection from '$lib/components/forms/FormSection.svelte';
 	import { useClientFetch } from '$lib/api/clientFetch';
 	import { getFriendlyApiMessage } from '$lib/api/apiErrors';
-	import { getCurrentUser, mapToFrontendUser } from '$lib/services/authService';
+	import { getCurrentUser, mapToFrontendUser, refreshSession } from '$lib/services/authService';
 	import {
 		changeMyUsername,
 		deleteMyAccount,
@@ -22,7 +22,7 @@
 
 	const getClientFetch = useClientFetch();
 
-	let displayName = data.user.name ?? '';
+	let profileName = data.user.name ?? '';
 	let phoneNumber = data.user.phoneNumber ?? '';
 	let birthYear = data.user.birthYear ?? null;
 	let newUserName = data.user.userName;
@@ -32,11 +32,18 @@
 	let isExporting = false;
 	let isDeleting = false;
 	let deleteDialogOpen = false;
-	let deletePassword = '';
 	let deleteConfirmation = '';
+	$: currentUser = $auth.user ?? data.user;
 
-	async function refreshSession() {
+	async function refreshCurrentUserOnce() {
 		const me = await getCurrentUser(getClientFetch());
+		if (me) auth.setUser(mapToFrontendUser(me));
+	}
+
+	async function refreshAuthSessionAndUserOnce() {
+		const fetchFn = getClientFetch();
+		await refreshSession(fetchFn);
+		const me = await getCurrentUser(fetchFn);
 		if (me) auth.setUser(mapToFrontendUser(me));
 	}
 
@@ -46,12 +53,12 @@
 		isSaving = true;
 		try {
 			const result = await updateMyProfile(getClientFetch(), {
-				name: displayName || null,
+				name: profileName || null,
 				phoneNumber: phoneNumber || null,
 				birthYear
 			});
 			status = result.message || 'Profilen är uppdaterad.';
-			await refreshSession();
+			await refreshCurrentUserOnce();
 			toasts.success(status);
 		} catch (err) {
 			error = getFriendlyApiMessage(err, 'Profilen kunde inte sparas.');
@@ -64,10 +71,17 @@
 	async function saveUsername() {
 		error = '';
 		status = '';
+		const trimmedUserName = newUserName.trim();
+		if (!trimmedUserName) {
+			error = 'Skriv ett användarnamn först.';
+			return;
+		}
+
 		try {
-			const result = await changeMyUsername(getClientFetch(), { newUserName });
+			const result = await changeMyUsername(getClientFetch(), { newUserName: trimmedUserName });
+			newUserName = trimmedUserName;
 			status = result.message || 'Användarnamnet är uppdaterat.';
-			await refreshSession();
+			await refreshAuthSessionAndUserOnce();
 			toasts.success(status);
 		} catch (err) {
 			error = getFriendlyApiMessage(err, 'Användarnamnet kunde inte sparas.');
@@ -100,7 +114,6 @@
 
 	function openDeleteDialog() {
 		deleteDialogOpen = true;
-		deletePassword = '';
 		deleteConfirmation = '';
 	}
 
@@ -116,7 +129,7 @@
 		status = '';
 		isDeleting = true;
 		try {
-			const result = await deleteMyAccount(getClientFetch(), deletePassword || null);
+			const result = await deleteMyAccount(getClientFetch(), null);
 			auth.clear();
 			deleteDialogOpen = false;
 			toasts.success(result.message || 'Kontot är raderat.');
@@ -137,13 +150,13 @@
 
 <section class="section profile-page">
 	<div class="container profile-grid">
-		<ProfileCard user={data.user} />
+		<ProfileCard user={currentUser} />
 
 		<FormSection title="Dina uppgifter">
 			<form class="form-grid" on:submit|preventDefault={saveProfile}>
 				<div class="two-column">
 					<FormField label="Namn" id="profile-name">
-						<input id="profile-name" bind:value={displayName} />
+						<input id="profile-name" bind:value={profileName} />
 					</FormField>
 					<FormField label="Telefon" id="profile-phone">
 						<input id="profile-phone" bind:value={phoneNumber} />
@@ -250,14 +263,6 @@
 			<form class="form-grid" on:submit|preventDefault={deleteAccount}>
 				<FormField label="Skriv RADERA för att bekräfta" id="delete-confirmation">
 					<input id="delete-confirmation" bind:value={deleteConfirmation} autocomplete="off" />
-				</FormField>
-				<FormField label="Lösenord" id="delete-password">
-					<input
-						id="delete-password"
-						type="password"
-						bind:value={deletePassword}
-						autocomplete="current-password"
-					/>
 				</FormField>
 				<div class="delete-actions">
 					<Button type="button" variant="ghost" disabled={isDeleting} on:click={closeDeleteDialog}

--- a/Client/src/routes/profile/username/+page.svelte
+++ b/Client/src/routes/profile/username/+page.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import AuthPanel from '$lib/components/auth/AuthPanel.svelte';
+	import FormField from '$lib/components/forms/FormField.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { useClientFetch } from '$lib/api/clientFetch';
+	import { getFriendlyApiMessage } from '$lib/api/apiErrors';
+	import { refreshSession } from '$lib/services/authService';
+	import { changeMyUsername } from '$lib/services/userService';
+	import { toasts } from '$lib/stores/toastStore';
+
+	export let data;
+
+	const getClientFetch = useClientFetch();
+
+	let newUserName = '';
+	let error = '';
+	let isSaving = false;
+
+	async function saveUsername() {
+		const trimmedUserName = newUserName.trim();
+		if (!trimmedUserName) {
+			error = 'Skriv ett användarnamn först.';
+			return;
+		}
+
+		error = '';
+		isSaving = true;
+		try {
+			const fetchFn = getClientFetch();
+			const result = await changeMyUsername(fetchFn, { newUserName: trimmedUserName });
+			await refreshSession(fetchFn);
+			toasts.success(result.message || 'Användarnamnet är sparat.');
+			await goto(data.returnUrl);
+		} catch (err) {
+			error = getFriendlyApiMessage(err, 'Användarnamnet kunde inte sparas.');
+			toasts.error(error);
+		} finally {
+			isSaving = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Välj användarnamn | SarasBlogg</title>
+</svelte:head>
+
+<AuthPanel
+	title="Välj användarnamn"
+	text="Du behöver välja ett användarnamn innan du kan fortsätta."
+>
+	<form class="username-form" on:submit|preventDefault={saveUsername}>
+		<FormField label="Användarnamn" id="setup-username">
+			<input id="setup-username" bind:value={newUserName} minlength="3" autocomplete="username" />
+		</FormField>
+		<Button type="submit" disabled={isSaving}>
+			{isSaving ? 'Sparar...' : 'Spara användarnamn'}
+		</Button>
+		{#if error}
+			<p class="status-text status-text--error">{error}</p>
+		{/if}
+	</form>
+</AuthPanel>
+
+<style>
+	.username-form {
+		display: grid;
+		gap: 1rem;
+	}
+</style>

--- a/Client/src/routes/profile/username/+page.ts
+++ b/Client/src/routes/profile/username/+page.ts
@@ -1,0 +1,38 @@
+import { redirect } from '@sveltejs/kit';
+import {
+	ensureBasePath,
+	isSafeLocalPath,
+	loginRoute,
+	routePathFromUrl,
+	routes
+} from '$lib/utils/routes';
+
+function normalizePath(path: string) {
+	const withoutQuery = path.split('?')[0] ?? '/';
+	const normalized = withoutQuery.replace(/\/+$/, '');
+	return normalized || '/';
+}
+
+function safeReturnUrl(value: string | null) {
+	if (!isSafeLocalPath(value)) return routes.profile;
+
+	const returnUrl = ensureBasePath(value);
+	if (normalizePath(returnUrl) === normalizePath(routes.profileUsername)) return routes.profile;
+
+	return returnUrl;
+}
+
+export const load = async ({ parent, url }) => {
+	const { user } = await parent();
+	const returnUrl = safeReturnUrl(url.searchParams.get('returnUrl'));
+
+	if (!user) {
+		throw redirect(303, loginRoute(routePathFromUrl(url)));
+	}
+
+	if (!user.requiresUsernameSetup) {
+		throw redirect(303, returnUrl);
+	}
+
+	return { user, returnUrl };
+};


### PR DESCRIPTION
## Summary

Stabilizes the Svelte username setup/session flow and fixes stale-auth issues after username changes.

### Fixed

* automatic first-login username setup redirect
* stale bearer/session after username change
* `/api/users/me` resolving by mutable username claim
* repeated auth instability after setup completion

### Key changes

* root auth flow now runs client-side for runtime-auth correctness
* `/api/users/me` now resolves users via stable `ClaimTypes.NameIdentifier`
* `refresh-session` now refreshes API auth cookie/session consistently
* username setup/save flow refreshes auth once before next authenticated request
* removed remaining route helper hash access issue

### Preserved

* no auth invalidation loops
* no polling
* no reactive redirect loops
* Razor behavior unchanged
* temporary mobile hybrid auth compatibility remains intact
* delete-account password removal remains intact

### Verification

* npm run check ✅
* npm run build ✅
* dotnet build ✅
* verified no `/me` spam loop
* verified username updates propagate immediately after save
