### PR TITLE
feat(guidance): add reflective footer guidance experience

### DIFF
--- a/API/Controllers/Guidance/GuidanceController.cs
+++ b/API/Controllers/Guidance/GuidanceController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using SarasBloggAPI.DTOs.Guidance;
+using SarasBloggAPI.Services.Guidance;
+
+namespace SarasBloggAPI.Controllers.Guidance;
+
+[ApiController]
+[Route("api/[controller]")]
+[EnableRateLimiting("guidance")]
+public class GuidanceController : ControllerBase
+{
+    private readonly GuidanceService _guidanceService;
+    private readonly ILogger<GuidanceController> _logger;
+
+    public GuidanceController(GuidanceService guidanceService, ILogger<GuidanceController> logger)
+    {
+        _guidanceService = guidanceService;
+        _logger = logger;
+    }
+
+    [HttpPost]
+    [AllowAnonymous]
+    public async Task<ActionResult<GuidanceResponse>> Create(
+        [FromBody] GuidanceRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.Input))
+        {
+            return BadRequest(new
+            {
+                error = "invalid_request",
+                message = "Skriv ett ord eller en kort fråga."
+            });
+        }
+
+        try
+        {
+            var result = await _guidanceService.GenerateAsync(request, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(result.Guidance))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+                {
+                    error = "guidance_unavailable",
+                    message = "Vägledningen kunde inte hämtas just nu. Försök igen om en stund."
+                });
+            }
+
+            return Ok(result);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Could not generate footer guidance.");
+
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "guidance_unavailable",
+                message = "Vägledningen kunde inte hämtas just nu. Försök igen om en stund."
+            });
+        }
+    }
+}

--- a/API/DTOs/Guidance/GuidanceRequest.cs
+++ b/API/DTOs/Guidance/GuidanceRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SarasBloggAPI.DTOs.Guidance;
+
+public class GuidanceRequest
+{
+    [Required]
+    [StringLength(180, MinimumLength = 1, ErrorMessage = "Skriv ett ord eller en kort fråga.")]
+    public string Input { get; set; } = string.Empty;
+}

--- a/API/DTOs/Guidance/GuidanceResponse.cs
+++ b/API/DTOs/Guidance/GuidanceResponse.cs
@@ -1,0 +1,6 @@
+namespace SarasBloggAPI.DTOs.Guidance;
+
+public class GuidanceResponse
+{
+    public string Guidance { get; set; } = string.Empty;
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -17,6 +17,7 @@ using System.Security.Claims;
 using AngleSharp.Dom;
 using Ganss.Xss;
 using Microsoft.AspNetCore.RateLimiting;
+using SarasBloggAPI.Services.Guidance;
 using SarasBloggAPI.Services.Tarot;
 
 
@@ -249,6 +250,13 @@ namespace SarasBloggAPI
                     config.Window = TimeSpan.FromMinutes(1);
                     config.QueueLimit = 0;
                 });
+
+                options.AddFixedWindowLimiter("guidance", config =>
+                {
+                    config.PermitLimit = 8;
+                    config.Window = TimeSpan.FromMinutes(1);
+                    config.QueueLimit = 0;
+                });
             });
 
             // FILE HELPER: Local för Development, GitHub för Test/Prod
@@ -270,6 +278,7 @@ namespace SarasBloggAPI
             builder.Services.AddScoped<IAboutMeImageService, AboutMeImageService>();
             
             builder.Services.AddScoped<TarotService>();
+            builder.Services.AddScoped<GuidanceService>();
             
             builder.Services.AddScoped<ContactMeManager>();
             builder.Services.AddScoped<UserManagerService>();

--- a/API/Services/Guidance/GuidanceService.cs
+++ b/API/Services/Guidance/GuidanceService.cs
@@ -1,0 +1,141 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using SarasBloggAPI.DTOs.Guidance;
+
+namespace SarasBloggAPI.Services.Guidance;
+
+public class GuidanceService
+{
+    private const string OpenAiEndpoint = "https://api.openai.com/v1/chat/completions";
+    private readonly IConfiguration _configuration;
+    private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(12) };
+
+    public GuidanceService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public async Task<GuidanceResponse> GenerateAsync(GuidanceRequest request, CancellationToken cancellationToken)
+    {
+        var input = NormalizeInput(request.Input);
+        var response = await CallOpenAI(input, cancellationToken);
+
+        return new GuidanceResponse
+        {
+            Guidance = CleanResponse(response)
+        };
+    }
+
+    private static string NormalizeInput(string input)
+    {
+        return Regex.Replace(input.Trim(), @"\s+", " ");
+    }
+
+    private static object[] BuildMessages(string input)
+    {
+        return
+        [
+            new
+            {
+                role = "system",
+                content = """
+Du skriver små vägledande reflektioner för en svensk blogg.
+Svara alltid endast på svenska.
+Svara med 1-3 korta meningar och högst ungefär 45 ord.
+Tonen ska vara varm, lugn, jordnära, personlig och lätt poetisk.
+Ta användarens ord eller fråga på allvar och låt svaret kännas specifikt för det.
+Skriv som en liten inre kompass, inte som en AI-assistent, chatbot, terapeut eller spådam.
+Ge inga säkra framtidslöften, ingen diagnos och ingen medicinsk, juridisk eller ekonomisk rådgivning.
+Använd inte markdown, rubriker, listor, emojis eller citattecken runt svaret.
+Undvik fraser som "som AI", "jag kan hjälpa dig", "det beror på" och generiskt fyllnadsspråk.
+"""
+            },
+            new
+            {
+                role = "user",
+                content = $"""
+Användarens ord eller fråga:
+{input}
+
+Skriv en kort reflektion som svarar på detta.
+"""
+            }
+        ];
+    }
+
+    private async Task<string> CallOpenAI(string input, CancellationToken cancellationToken)
+    {
+        var apiKey = _configuration["OpenAI:ApiKey"];
+
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new InvalidOperationException("OpenAI API key is missing.");
+
+        var requestBody = new
+        {
+            model = "gpt-4o-mini",
+            messages = BuildMessages(input),
+            temperature = 0.75,
+            max_tokens = 90
+        };
+
+        var json = JsonSerializer.Serialize(requestBody);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, OpenAiEndpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"OpenAI guidance request failed: {response.StatusCode}");
+
+        using var doc = JsonDocument.Parse(responseContent);
+        var content = doc.RootElement
+            .GetProperty("choices")[0]
+            .GetProperty("message")
+            .GetProperty("content")
+            .GetString();
+
+        if (string.IsNullOrWhiteSpace(content))
+            throw new InvalidOperationException("OpenAI returned an empty guidance response.");
+
+        return content;
+    }
+
+    private static string CleanResponse(string response)
+    {
+        var lines = response
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(line => Regex.Replace(line, @"^[-*•\d.)\s]+", ""));
+
+        var cleaned = string.Join(" ", lines);
+        cleaned = Regex.Replace(cleaned, @"[*_`#>]", "");
+        cleaned = cleaned.Trim().Trim('"', '“', '”');
+        cleaned = Regex.Replace(cleaned, @"\s+", " ");
+
+        return LimitResponse(cleaned);
+    }
+
+    private static string LimitResponse(string response)
+    {
+        var sentences = Regex.Matches(response, @"[^.!?]+[.!?]+|[^.!?]+$")
+            .Select(match => match.Value.Trim())
+            .Where(sentence => sentence.Length > 0)
+            .Take(3);
+
+        var limited = string.Join(" ", sentences);
+        const int maxLength = 360;
+
+        if (limited.Length <= maxLength)
+            return limited;
+
+        var cutoff = limited.LastIndexOf(' ', maxLength);
+        if (cutoff < 120)
+            cutoff = maxLength;
+
+        return limited[..cutoff].TrimEnd(',', ';', ':', ' ') + ".";
+    }
+}

--- a/Client/src/lib/components/layout/Footer.svelte
+++ b/Client/src/lib/components/layout/Footer.svelte
@@ -1,11 +1,71 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
+	import { onMount } from 'svelte';
 	import { brand } from '$lib/config/site';
+	import { ApiError, getFriendlyApiMessage } from '$lib/api/apiErrors';
+	import { useClientFetch } from '$lib/api/clientFetch';
 	import BrandLockup from '$lib/components/brand/BrandLockup.svelte';
 	import SocialLinks from '$lib/components/layout/SocialLinks.svelte';
+	import { requestGuidance } from '$lib/services/guidanceService';
+	import { auth } from '$lib/stores/authStore';
 	import { routes } from '$lib/utils/routes';
 
 	const dispatch = createEventDispatcher<{ privacy: void }>();
+	const getClientFetch = useClientFetch();
+	const guestGuidanceKey = 'sarasblogg.footerGuidance.guestUsed';
+
+	let guidanceInput = '';
+	let guidanceResponse = '';
+	let guidanceError = '';
+	let isGuidanceLoading = false;
+	let guestHasUsedGuidance = false;
+
+	$: isLoggedIn = Boolean($auth.user);
+	$: hasReachedGuestLimit = !isLoggedIn && guestHasUsedGuidance;
+	$: guidanceInputValue = guidanceInput.trim();
+	$: guidanceSubmitDisabled =
+		isGuidanceLoading || guidanceInputValue.length === 0 || hasReachedGuestLimit;
+
+	onMount(() => {
+		guestHasUsedGuidance = sessionStorage.getItem(guestGuidanceKey) === 'true';
+	});
+
+	function markGuestGuidanceUsed() {
+		if (isLoggedIn) return;
+
+		guestHasUsedGuidance = true;
+		sessionStorage.setItem(guestGuidanceKey, 'true');
+	}
+
+	function getGuidanceErrorMessage(error: unknown) {
+		if (error instanceof ApiError && error.status === 429) {
+			return 'Vänta en liten stund innan du frågar igen.';
+		}
+
+		return getFriendlyApiMessage(
+			error,
+			'Vägledningen kunde inte hämtas just nu. Försök igen om en stund.'
+		);
+	}
+
+	async function submitGuidance() {
+		if (guidanceSubmitDisabled) return;
+
+		isGuidanceLoading = true;
+		guidanceError = '';
+		guidanceResponse = '';
+
+		try {
+			const result = await requestGuidance(getClientFetch(), { input: guidanceInputValue });
+			guidanceResponse = result.guidance;
+			guidanceInput = '';
+			markGuestGuidanceUsed();
+		} catch (error) {
+			guidanceError = getGuidanceErrorMessage(error);
+		} finally {
+			isGuidanceLoading = false;
+		}
+	}
 </script>
 
 <footer class="site-footer">
@@ -27,12 +87,37 @@
 			<SocialLinks />
 		</div>
 
-		<form class="newsletter" aria-label="Nyhetsbrev" on:submit|preventDefault>
-			<h2>Nyhetsbrev</h2>
-			<p>Få inspiration och nya inlägg direkt till din inkorg.</p>
-			<div>
-				<input type="email" placeholder="Din e-postadress" aria-label="Din e-postadress" />
-				<button type="submit" aria-label="Anmäl till nyhetsbrev">→</button>
+		<form class="guidance" aria-label="Dagens kompassord" on:submit|preventDefault={submitGuidance}>
+			<h2>Dagens kompassord</h2>
+			<p>Ställ en fråga eller skriv ett ord, så får du ett litet vägledande svar.</p>
+			<div class="guidance-row">
+				<input
+					type="text"
+					bind:value={guidanceInput}
+					placeholder="Vad behöver du vägledning kring?"
+					aria-label="Vad behöver du vägledning kring?"
+					maxlength="180"
+					disabled={isGuidanceLoading || hasReachedGuestLimit}
+				/>
+				<button type="submit" aria-label="Skicka fråga" disabled={guidanceSubmitDisabled}>→</button>
+			</div>
+
+			<div class="guidance-status" aria-live="polite">
+				{#if isGuidanceLoading}
+					<p class="guidance-note guidance-note--loading">Lyssnar in...</p>
+				{:else}
+					{#if guidanceResponse}
+						<p class="guidance-response"><span aria-hidden="true">✦</span>{guidanceResponse}</p>
+					{/if}
+
+					{#if guidanceError}
+						<p class="guidance-note guidance-note--error">{guidanceError}</p>
+					{:else if hasReachedGuestLimit}
+						<p class="guidance-note">
+							Vill du fråga igen? <a href={routes.login}>Logga in</a> så finns kompassordet kvar.
+						</p>
+					{/if}
+				{/if}
 			</div>
 		</form>
 	</div>
@@ -92,7 +177,7 @@
 		color: var(--color-muted);
 	}
 
-	.newsletter button {
+	.guidance button {
 		display: grid;
 		place-items: center;
 		width: 2.45rem;
@@ -113,24 +198,98 @@
 		z-index: 1;
 	}
 
-	.newsletter div {
+	.guidance-row {
 		display: grid;
 		grid-template-columns: 1fr auto;
 		gap: 0.5rem;
 		margin-top: 1rem;
 	}
 
-	.newsletter input {
+	.guidance input {
 		min-width: 0;
 		border: 1px solid var(--color-border);
 		border-radius: 0.75rem;
 		background: #fff;
 		padding: 0.75rem 0.9rem;
+		color: var(--color-text);
 	}
 
-	.newsletter button {
+	.guidance input:disabled {
+		background: rgba(255, 250, 244, 0.7);
+		color: var(--color-muted);
+	}
+
+	.guidance button {
 		border: 0;
 		background: var(--color-accent);
+		transition:
+			transform 160ms ease,
+			opacity 160ms ease,
+			background 160ms ease;
+	}
+
+	.guidance button:not(:disabled):hover {
+		transform: translateX(1px);
+		background: #c98277;
+	}
+
+	.guidance button:disabled {
+		cursor: default;
+		opacity: 0.52;
+	}
+
+	.guidance-status {
+		display: grid;
+		gap: 0.65rem;
+		min-height: 0;
+		margin-top: 1rem;
+	}
+
+	.guidance-response,
+	.guidance-note {
+		margin: 0;
+		max-width: none;
+	}
+
+	.guidance-response {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 0.72rem;
+		align-items: start;
+		padding: 0.9rem 1rem;
+		border: 1px solid rgba(217, 155, 121, 0.22);
+		border-radius: 0.9rem;
+		background: rgba(255, 250, 244, 0.78);
+		box-shadow: 0 10px 28px rgba(95, 74, 59, 0.07);
+		color: var(--color-heading);
+		line-height: 1.55;
+	}
+
+	.guidance-response span {
+		color: var(--color-accent);
+		font-size: 1.1rem;
+		line-height: 1.45;
+	}
+
+	.guidance-note {
+		color: var(--color-muted);
+		font-size: 0.92rem;
+		line-height: 1.5;
+	}
+
+	.guidance-note a {
+		color: #9f664f;
+		font-weight: 700;
+		text-decoration: underline;
+		text-underline-offset: 0.2em;
+	}
+
+	.guidance-note--loading {
+		animation: soft-pulse 1.4s ease-in-out infinite;
+	}
+
+	.guidance-note--error {
+		color: #9b3f35;
 	}
 
 	.footer-bottom {
@@ -172,6 +331,21 @@
 		.footer-bottom {
 			grid-template-columns: 1fr;
 			flex-direction: column;
+		}
+
+		.guidance-row {
+			grid-template-columns: minmax(0, 1fr) auto;
+		}
+	}
+
+	@keyframes soft-pulse {
+		0%,
+		100% {
+			opacity: 0.62;
+		}
+
+		50% {
+			opacity: 1;
 		}
 	}
 </style>

--- a/Client/src/lib/services/guidanceService.ts
+++ b/Client/src/lib/services/guidanceService.ts
@@ -1,0 +1,6 @@
+import { apiPost, type ApiFetch } from '$lib/api/apiClient';
+import type { GuidanceRequest, GuidanceResponse } from '$lib/types/guidance';
+
+export function requestGuidance(fetchFn: ApiFetch, request: GuidanceRequest) {
+	return apiPost<GuidanceResponse>(fetchFn, '/api/guidance', request);
+}

--- a/Client/src/lib/types/guidance.ts
+++ b/Client/src/lib/types/guidance.ts
@@ -1,0 +1,7 @@
+export type GuidanceRequest = {
+	input: string;
+};
+
+export type GuidanceResponse = {
+	guidance: string;
+};


### PR DESCRIPTION
## Summary

Adds a lightweight AI-powered reflective guidance feature to the Svelte footer, replacing the unused newsletter section.

The feature provides short Swedish-only “compass-style” reflective responses based on a user’s word, feeling, or question.

## Architecture

Implemented as a separate GuidanceService rather than extending TarotService.

Reasoning:
- feature is not card-based
- avoids coupling blog/footer UX to tarot interpretation logic
- keeps prompts focused and maintainable
- still reuses the existing OpenAI integration patterns and API-first architecture

Razor frontend remains untouched.

## Features

- soft reflective guidance responses
- concise “fortune-cookie” style tone
- Swedish-only
- mobile-first footer UX
- subtle loading/error states
- no chatbot interface
- no tarot card UI
- no deterministic predictions

## Guest vs Logged-In Behavior

- guests: one request per browser session via sessionStorage
- logged-in users: unlimited/repeat usage
- backend rate limiting remains the actual protection layer

This is intentionally a UX limitation rather than a security boundary.

## Verification

Verified:
- API build
- Razor build
- Svelte check/build
- mobile footer layout
- response rendering
- loading/error states
- guest limitation flow
- logged-in repeat flow

No Razor regressions observed.